### PR TITLE
Add reuse badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ SPDX-License-Identifier: Apache-2.0
 [![Documentation Status](https://readthedocs.org/projects/outpost-sentry/badge/?version=latest)](https://outpost-sentry.readthedocs.io/en/latest/?badge=latest)
 ![GitHub Release](https://img.shields.io/github/v/release/outpost-os/sentry-kernel)
 ![GitHub License](https://img.shields.io/github/license/outpost-os/sentry-kernel)
-
+[![REUSE status](https://api.reuse.software/badge/github.com/outpost-os/sentry-kernel)](https://api.reuse.software/info/github.com/outpost-os/sentry-kernel)
 
 
 ## About

--- a/README.md
+++ b/README.md
@@ -203,12 +203,12 @@ A typical usage of robot files of the kernel would be, considering the following
 
 ```console
 pyocd list
-  #   Probe/Board       Unique ID                  Target            
+  #   Probe/Board       Unique ID                  Target
 ---------------------------------------------------------------------
-  0   STLINK-V3         004300483232510239353236   ✔︎ stm32u5a5zjtxq  
-      NUCLEO-U5A5ZJ-Q                                                
-                                                                     
-  1   STM32 STLink      0671FF575251717867205336   ✔︎ stm32f429zitx   
+  0   STLINK-V3         004300483232510239353236   ✔︎ stm32u5a5zjtxq
+      NUCLEO-U5A5ZJ-Q
+
+  1   STM32 STLink      0671FF575251717867205336   ✔︎ stm32f429zitx
       DISCO-F429Z
 ```
 


### PR DESCRIPTION
Project is registered in REUSE db.

see: https://api.reuse.software/info/github.com/outpost-os/sentry-kernel

