### PR TITLE
SHM: adding sys_shm_get_infos() syscall

### DIFF
--- a/.github/workflows/gnulinux.yml
+++ b/.github/workflows/gnulinux.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   forge_matrix:
-    runs-on: ${{ vars.DEFAULT_RUNNER_NAME }}
+    runs-on: ubuntu-latest
     container:
       image: python:3.9.14-alpine3.16
     steps:
@@ -58,7 +58,7 @@ jobs:
     defaults:
       run:
         shell: bash
-    runs-on: ${{ vars.DEFAULT_RUNNER_NAME }}
+    runs-on: ubuntu-latest
     container:
       image: ${{ matrix.operating_system }}
     steps:
@@ -130,7 +130,7 @@ jobs:
     defaults:
       run:
         shell: bash
-    runs-on: ${{ vars.DEFAULT_RUNNER_NAME }}
+    runs-on: ubuntu-latest
     container:
       image: 'mesonbuild/ubuntu-rolling'
     steps:
@@ -194,7 +194,7 @@ jobs:
     defaults:
       run:
         shell: bash
-    runs-on: ${{ vars.DEFAULT_RUNNER_NAME }}
+    runs-on: ubuntu-latest
     container:
       image: 'mesonbuild/ubuntu-rolling'
     steps:

--- a/.github/workflows/proof.yml
+++ b/.github/workflows/proof.yml
@@ -19,7 +19,7 @@ jobs:
     defaults:
       run:
         shell: bash
-    runs-on: ${{ vars.DEFAULT_RUNNER_NAME }}
+    runs-on: ubuntu-latest
     container: 'pthierry38/framac-runner:29'
     timeout-minutes: 60
     steps:

--- a/autotest/src/tests/test_shm.c
+++ b/autotest/src/tests/test_shm.c
@@ -66,6 +66,26 @@ void test_shm_invalidmap(void) {
     TEST_END();
 }
 
+void test_shm_infos(void) {
+    Status res;
+    shmh_t shm;
+    shm_infos_t infos;
+    TEST_START();
+    res = sys_get_shm_handle(shms[0].id);
+    copy_to_user((uint8_t*)&shm, sizeof(shmh_t));
+    ASSERT_EQ(res, STATUS_OK);
+    res = sys_shm_get_infos(shm);
+    copy_to_user((uint8_t*)&infos, sizeof(shm_infos_t));
+
+    ASSERT_EQ(res, STATUS_OK);
+    ASSERT_EQ(infos.label, shms[0].id);
+    ASSERT_EQ(infos.handle, shm);
+    ASSERT_EQ((uint32_t)infos.base, (uint32_t)shms[0].baseaddr);
+    ASSERT_EQ((uint32_t)infos.len, (uint32_t)shms[0].size);
+
+    TEST_END();
+}
+
 void test_shm_creds_on_mapped(void) {
     Status res;
     shmh_t shm;
@@ -185,6 +205,7 @@ void test_shm(void) {
     test_shm_mapunmap();
     test_shm_map_unmappable();
     test_shm_creds_on_mapped();
+    test_shm_infos();
     test_shm_allows_idle();
     TEST_SUITE_END("sys_map_shm");
 }

--- a/doc/concepts/uapi/syscalls.rst
+++ b/doc/concepts/uapi/syscalls.rst
@@ -140,6 +140,11 @@ Syscall definition
 .. include:: syscalls/shm_set_credential.rst
 
 .. index::
+  single: sys_shm_get_infos; definition
+  single: sys_shm_get_infos; usage
+.. include:: syscalls/shm_get_infos.rst
+
+.. index::
   single: sys_wait_for_event; definition
   single: sys_wait_for_event; usage
 .. include:: syscalls/waitforevent.rst

--- a/doc/concepts/uapi/syscalls/meson.build
+++ b/doc/concepts/uapi/syscalls/meson.build
@@ -22,6 +22,7 @@ syscalls_src = files(
   'shm_map.rst',
   'shm_unmap.rst',
   'shm_set_credential.rst',
+  'shm_get_infos.rst',
   'send_ipc.rst',
   'waitforevent.rst',
 )

--- a/doc/concepts/uapi/syscalls/shm_get_infos.rst
+++ b/doc/concepts/uapi/syscalls/shm_get_infos.rst
@@ -19,12 +19,12 @@ sys_shm_get_infos
 **Usage**
 
    In Sentry, as explained in :ref:`SHM model definition chapter <shm_principles>`, a shared memory
-   hold credential for its owner and user task. It also hold some memory-related shm_get_infos
+   holds credential for its owner and user task. It also hold some memory-related shm_get_infos
    such as base address and size.
 
-   These informations are useful to get back un userspace without requiring any DTS forge at application level.
+   These information set is useful to get back in user-space without requiring any DTS forge at application level.
 
-   These informations can be received through this syscall, by fullfilling the shm_infos_t structure
+   These informations can be received through this syscall, by fulfilling the shm_infos_t structure
    declared by the UAPI in the SVC Exchange area. The `shm_infos_t` is defined in the
    UAPI `<types.h>` header in C or through the uapi.systypes Rust mod.
 
@@ -32,7 +32,7 @@ sys_shm_get_infos
       :linenos:
       :caption: shm_infos_t structure definition
 
-      /* Exchange event header for all events received in SVC Exchange area */
+      /* SHM informations data structure */
       typedef struct shm_infos {
         shmh_t   handle;  /*< SHM handle */
         uint32_t label;   /*< SHM label */
@@ -43,11 +43,11 @@ sys_shm_get_infos
 
 
 
-   The lonely input required for this syscall is the SHM handle, as given by the
+   The only input required for this syscall is the SHM handle, as given by the
    `sys_get_shmhandle()` syscall.
 
-   When a given SHM credentials for the current job is upgraded, the `sys_shm_get_infos()`
-   returns an uptodate content synchronously.
+   When a given SHM credentials set for the current job is updated, the `sys_shm_get_infos()`
+   returns an up-to-date content synchronously.
 
    .. code-block:: C
       :linenos:

--- a/doc/concepts/uapi/syscalls/shm_get_infos.rst
+++ b/doc/concepts/uapi/syscalls/shm_get_infos.rst
@@ -1,0 +1,81 @@
+sys_shm_get_infos
+"""""""""""""""""
+.. _uapi_shm_get_infos:
+
+**API definition**
+
+   .. code-block:: rust
+      :caption: Rust UAPI for shm_get_infos syscall
+
+      mod uapi {
+         fn shm_get_infos(shm: shm_t) -> Status
+      }
+
+   .. code-block:: c
+      :caption: C UAPI for shm_get_infos syscall
+
+      enum Status sys_shm_get_infos(shmh_t shm);
+
+**Usage**
+
+   In Sentry, as explained in :ref:`SHM model definition chapter <shm_principles>`, a shared memory
+   hold credential for its owner and user task. It also hold some memory-related shm_get_infos
+   such as base address and size.
+
+   These informations are useful to get back un userspace without requiring any DTS forge at application level.
+
+   These informations can be received through this syscall, by fullfilling the shm_infos_t structure
+   declared by the UAPI in the SVC Exchange area. The `shm_infos_t` is defined in the
+   UAPI `<types.h>` header in C or through the uapi.systypes Rust mod.
+
+   .. code-block:: C
+      :linenos:
+      :caption: shm_infos_t structure definition
+
+      /* Exchange event header for all events received in SVC Exchange area */
+      typedef struct shm_infos {
+        shmh_t   handle;  /*< SHM handle */
+        uint32_t label;   /*< SHM label */
+        size_t   base;    /*< SHM base address */
+        size_t   len;     /*< SHM length in bytes */
+        uint32_t perms;   /*< SHM permissions (mask of SHMPermission) */
+      } shm_infos_t;
+
+
+
+   The lonely input required for this syscall is the SHM handle, as given by the
+   `sys_get_shmhandle()` syscall.
+
+   When a given SHM credentials for the current job is upgraded, the `sys_shm_get_infos()`
+   returns an uptodate content synchronously.
+
+   .. code-block:: C
+      :linenos:
+      :caption: sample bare usage of sys_shm_get_infos
+
+      uint32_t my_shm_label=0xf00UL;
+      taskh_t myself;
+      shm_infos_t infos;
+      if (sys_get_task_handle(myself_label) != STATUS_OK) {
+         // [...]
+      }
+      copy_to_user(&myself, sizeof(taskh_t));
+      if (sys_get_shm_handle(my_shm_label) != STATUS_OK) {
+         // [...]
+      }
+      copy_to_user(&my_shm_handle, sizeof(shmh_t));
+
+      if (sys_shm_get_infos(my_shm_handle)) {
+        // [...]
+      }
+      copy_to_user(&infos, sizeof(shm_infos_t));
+      printf("SHM base address is %lx\n", infos.base);
+
+**Required capability**
+
+   None.
+
+**Return values**
+
+   * STATUS_INVALID if the SHM do not exist, target do not exist or is not owned or used by the calling task
+   * STATUS_OK

--- a/kernel/include/sentry/managers/memory.h
+++ b/kernel/include/sentry/managers/memory.h
@@ -111,6 +111,12 @@ kstatus_t mgr_mm_shm_is_shared(shmh_t shm, secure_bool_t * result);
 
 kstatus_t mgr_mm_shm_get_handle(uint32_t shm_id, shmh_t *handle);
 
+kstatus_t mgr_mm_shm_get_baseaddr(shmh_t shm, size_t *base);
+
+kstatus_t mgr_mm_shm_get_size(shmh_t shm, size_t *size);
+
+kstatus_t mgr_mm_shm_get_label(shmh_t shm, uint32_t *label);
+
 /* per user/owner properties requests */
 
 kstatus_t mgr_mm_shm_is_mapped_by(shmh_t shm, shm_user_t accessor, secure_bool_t * result);
@@ -122,6 +128,7 @@ kstatus_t mgr_mm_shm_is_writeable_by(shmh_t shm, shm_user_t accessor, secure_boo
 kstatus_t mgr_mm_shm_configure(shmh_t shm, shm_user_t target, shm_config_t const *config);
 
 kstatus_t mgr_mm_shm_declare_user(shmh_t shm, taskh_t task);
+
 
 /*
  * XXX:

--- a/kernel/include/sentry/managers/memory.h
+++ b/kernel/include/sentry/managers/memory.h
@@ -129,7 +129,6 @@ kstatus_t mgr_mm_shm_configure(shmh_t shm, shm_user_t target, shm_config_t const
 
 kstatus_t mgr_mm_shm_declare_user(shmh_t shm, taskh_t task);
 
-
 /*
  * XXX:
  *  In order to restore task mpu config w/ fast loading, region configuration

--- a/kernel/include/sentry/syscalls.h
+++ b/kernel/include/sentry/syscalls.h
@@ -69,4 +69,6 @@ stack_frame_t *gate_log(stack_frame_t *frame, __MAYBE_UNUSED uint32_t log_len);
 
 stack_frame_t *gate_get_dmahandle(stack_frame_t *frame, uint32_t streamlabel);
 
+stack_frame_t *gate_shm_get_infos(stack_frame_t *frame, shmh_t shm);
+
 #endif/*!SYSCALLS_H*/

--- a/kernel/src/arch/asm-generic/handler-svc-lut.c
+++ b/kernel/src/arch/asm-generic/handler-svc-lut.c
@@ -178,6 +178,10 @@ static stack_frame_t *lut_notsup(stack_frame_t *f) {
     return f;
 }
 
+static stack_frame_t *lut_shm_get_infos(stack_frame_t *frame) {
+    shmh_t shm = frame->r0;
+    return gate_shm_get_infos(frame, shm);
+}
 
 static const lut_svc_handler svc_lut[] = {
     lut_exit,
@@ -210,6 +214,7 @@ static const lut_svc_handler svc_lut[] = {
     lut_int_disable,
     lut_get_shmhandle,
     lut_get_dmahandle,
+    lut_shm_get_infos,
 };
 
 #define SYSCALL_NUM ARRAY_SIZE(svc_lut)

--- a/kernel/src/arch/asm-generic/handler-svc-lut.c
+++ b/kernel/src/arch/asm-generic/handler-svc-lut.c
@@ -183,6 +183,12 @@ static stack_frame_t *lut_shm_get_infos(stack_frame_t *frame) {
     return gate_shm_get_infos(frame, shm);
 }
 
+/* for not yet supported syscalls */
+static stack_frame_t *lut_unsuported(stack_frame_t *frame) {
+    mgr_task_set_sysreturn(sched_get_current(), STATUS_NO_ENTITY);
+    return frame;
+}
+
 static const lut_svc_handler svc_lut[] = {
     lut_exit,
     lut_get_prochandle,
@@ -214,6 +220,9 @@ static const lut_svc_handler svc_lut[] = {
     lut_int_disable,
     lut_get_shmhandle,
     lut_get_dmahandle,
+    lut_unsuported, /* DMA Start Stream */
+    lut_unsuported, /* DMA Stop Stream */
+    lut_unsuported, /* DMA Get Stream Status */
     lut_shm_get_infos,
 };
 

--- a/kernel/src/managers/memory/memory_shm.c
+++ b/kernel/src/managers/memory/memory_shm.c
@@ -144,6 +144,111 @@ end:
 }
 
 /**
+ * @fn get base address of the given SHM
+ *
+ * @param[in] shm: Shared memory handle that identify the SHM
+ * @param[out] base: base address of the SHM returned when found
+ */
+kstatus_t mgr_mm_shm_get_baseaddr(shmh_t shm, size_t *base)
+{
+    kstatus_t status = K_ERROR_INVPARAM;
+    kshmh_t const *kshm = shmh_to_kshmh(&shm);
+
+    /*@ assert \valid_read(kshm); */
+
+    if (unlikely(mgr_mm_configured() == SECURE_FALSE)) {
+        status = K_ERROR_BADSTATE;
+        goto end;
+    }
+    if (unlikely(base == NULL)) {
+        goto end;
+    }
+    /*@ assert \valid(base); */
+    /* check that id exsits */
+    if (unlikely(kshm->id >= SHM_LIST_SIZE)) {
+        goto end;
+    }
+    /* check that handle matches */
+    if (unlikely(shm_table[kshm->id].handle != shm)) {
+        goto end;
+    }
+    *base = shm_table[kshm->id].meta->baseaddr;
+    status = K_STATUS_OKAY;
+end:
+    return status;
+}
+
+/**
+ * @fn get size in bytes of the given SHM
+ *
+ * @param[in] shm: Shared memory handle that identify the SHM
+ * @param[out] size:  length in bytes of the SHM returned when found
+ */
+kstatus_t mgr_mm_shm_get_size(shmh_t shm, size_t *size)
+{
+    kstatus_t status = K_ERROR_INVPARAM;
+    kshmh_t const *kshm = shmh_to_kshmh(&shm);
+
+    /*@ assert \valid_read(kshm); */
+
+    if (unlikely(mgr_mm_configured() == SECURE_FALSE)) {
+        status = K_ERROR_BADSTATE;
+        goto end;
+    }
+    if (unlikely(size == NULL)) {
+        goto end;
+    }
+    /*@ assert \valid(size); */
+    /* check that id exsits */
+    if (unlikely(kshm->id >= SHM_LIST_SIZE)) {
+        goto end;
+    }
+    /* check that handle matches */
+    if (unlikely(shm_table[kshm->id].handle != shm)) {
+        goto end;
+    }
+    *size = shm_table[kshm->id].meta->size;
+    status = K_STATUS_OKAY;
+end:
+    return status;
+}
+
+/**
+ * @fn get label defined in DTS for the given SHM
+ *
+ * @param[in] shm: Shared memory handle that identify the SHM
+ * @param[out] label: identifier of the SHM as declared in the DTS, returned when found
+ */
+kstatus_t mgr_mm_shm_get_label(shmh_t shm, uint32_t *label)
+{
+    kstatus_t status = K_ERROR_INVPARAM;
+    kshmh_t const *kshm = shmh_to_kshmh(&shm);
+
+    /*@ assert \valid_read(kshm); */
+
+    if (unlikely(mgr_mm_configured() == SECURE_FALSE)) {
+        status = K_ERROR_BADSTATE;
+        goto end;
+    }
+    if (unlikely(label == NULL)) {
+        goto end;
+    }
+    /*@ assert \valid(label); */
+    /* check that id exsits */
+    if (unlikely(kshm->id >= SHM_LIST_SIZE)) {
+        goto end;
+    }
+    /* check that handle matches */
+    if (unlikely(shm_table[kshm->id].handle != shm)) {
+        goto end;
+    }
+    *label = shm_table[kshm->id].meta->shm_label;
+    status = K_STATUS_OKAY;
+end:
+    return status;
+}
+
+/**
  * @brief specify if the given SHM can be mapped by owner or user
  *
  * the secure boolean information is set through result argument

--- a/kernel/src/syscalls/meson.build
+++ b/kernel/src/syscalls/meson.build
@@ -27,6 +27,7 @@ syscalls = files(
     'sysgate_get_shmhandle.c',
     'sysgate_get_dmahandle.c',
     'sysgate_shm_set_creds.c',
+    'sysgate_shm_get_infos.c',
 )
 
 syscall_source_set.add(syscalls)

--- a/kernel/src/syscalls/sysgate_shm_get_infos.c
+++ b/kernel/src/syscalls/sysgate_shm_get_infos.c
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: 2023 Ledger SAS
+// SPDX-License-Identifier: Apache-2.0
+
+#include <sentry/syscalls.h>
+#include <uapi/types.h>
+#include <sentry/managers/memory.h>
+#include <sentry/sched.h>
+/** NOTE: memcpy impleted in Sentry zlib */
+#include <string.h>
+
+stack_frame_t *gate_shm_get_infos(stack_frame_t *frame, shmh_t shm)
+{
+    taskh_t current = sched_get_current();
+    shm_user_t user;
+    shm_infos_t shminfo = {0};
+    secure_bool_t result;
+    shm_infos_t *svcexch = NULL;
+    const task_meta_t *meta;
+
+    /*! NOTE: there is no need to check that the SHM handle exists, as the manager do that on its side */
+    if (unlikely(mgr_mm_shm_get_task_type(shm, current, &user) != K_STATUS_OKAY)) {
+        /* smoke test here, this branch should never happen */
+        /*@ assert(false); */
+        mgr_task_set_sysreturn(current, STATUS_INVALID);
+        goto end;
+    }
+    if (unlikely(user == SHM_TSK_NONE)) {
+        mgr_task_set_sysreturn(current, STATUS_INVALID);
+        goto end;
+    }
+    shminfo.handle = shm;
+    if (unlikely(mgr_mm_shm_get_label(shm, &shminfo.label) != K_STATUS_OKAY)) {
+        mgr_task_set_sysreturn(current, STATUS_INVALID);
+        goto end;
+    }
+    if (unlikely(mgr_mm_shm_get_baseaddr(shm, &shminfo.base) != K_STATUS_OKAY)) {
+        mgr_task_set_sysreturn(current, STATUS_INVALID);
+        goto end;
+    }
+    if (unlikely(mgr_mm_shm_get_size(shm, &shminfo.len) != K_STATUS_OKAY)) {
+        mgr_task_set_sysreturn(current, STATUS_INVALID);
+        goto end;
+    }
+    if (unlikely(mgr_mm_shm_is_mappable_by(shm, user, &result) != K_STATUS_OKAY)) {
+        mgr_task_set_sysreturn(current, STATUS_INVALID);
+        goto end;
+    }
+    if (result == SECURE_TRUE) {
+        shminfo.perms |= SHM_PERMISSION_MAP;
+    }
+    if (unlikely(mgr_mm_shm_is_writeable_by(shm, user, &result) != K_STATUS_OKAY)) {
+        mgr_task_set_sysreturn(current, STATUS_INVALID);
+        goto end;
+    }
+    if (result == SECURE_TRUE) {
+        shminfo.perms |= SHM_PERMISSION_WRITE;
+    }
+    /** TODO: transfer not yet supported */
+    /* push back structure on the SVC_Exchange area */
+    if (unlikely(mgr_task_get_metadata(current, &meta) != K_STATUS_OKAY)) {
+        panic(PANIC_KERNEL_INVALID_MANAGER_RESPONSE);
+    }
+    svcexch = (shm_infos_t*)meta->s_svcexchange;
+    memcpy(svcexch, &shminfo, sizeof(shm_infos_t));
+    mgr_task_set_sysreturn(current, STATUS_OK);
+end:
+    return frame;
+}

--- a/uapi/include/uapi/types.h
+++ b/uapi/include/uapi/types.h
@@ -292,7 +292,7 @@ typedef struct exchange_event {
     uint8_t data[]; /*< event data, varies depending on length field */
 } exchange_event_t;
 
-/* Exchange event header for all events received in SVC Exchange area */
+/* SHM informations data structure */
 typedef struct shm_infos {
     shmh_t   handle;  /*< SHM handle */
     uint32_t label;   /*< SHM label */

--- a/uapi/include/uapi/types.h
+++ b/uapi/include/uapi/types.h
@@ -24,6 +24,7 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include "handle.h"
 
 
 #ifdef __cplusplus
@@ -242,6 +243,7 @@ typedef enum Syscall {
   SYSCALL_DMA_START_SREAM,
   SYSCALL_DMA_STOP_STREAM,
   SYSCALL_DMA_GET_STREAM_STATUS,
+  SYSCALL_SHM_GET_INFOS,
 } Syscall;
 
 /**
@@ -289,6 +291,15 @@ typedef struct exchange_event {
     uint32_t source; /*< event source (task handle value). 0 means the kernel */
     uint8_t data[]; /*< event data, varies depending on length field */
 } exchange_event_t;
+
+/* Exchange event header for all events received in SVC Exchange area */
+typedef struct shm_infos {
+    shmh_t   handle;  /*< SHM handle */
+    uint32_t label;   /*< SHM label */
+    size_t   base;    /*< SHM base address */
+    size_t   len;     /*< SHM length in bytes */
+    uint32_t perms;   /*< SHM permissions (mask of SHMPermission) */
+} shm_infos_t;
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/uapi/include/uapi/uapi.h
+++ b/uapi/include/uapi/uapi.h
@@ -207,6 +207,12 @@ Status sys_send_signal(uint32_t resource, Signal signal_type);
 Status sys_shm_set_credential(shmh_t shm, taskh_t target, uint32_t shm_perm);
 
 /**
+ * Get SHM informations
+ */
+Status sys_shm_get_infos(shmh_t shm);
+
+
+/**
  * Sleep for a given amount of time
  *
  * POSIX upper layer(s): sleep(3), usleep(3)

--- a/uapi/uapi/syscall.rs
+++ b/uapi/uapi/syscall.rs
@@ -306,6 +306,10 @@ pub extern "C" fn sys_dma_get_stream_status(dmah: dmah_t) -> Status {
     syscall!(Syscall::DmaGetStreamStatus, dmah).into()
 }
 
+pub extern "C" fn sys_shm_get_infos(shm: shmh_t) -> Status {
+    syscall!(Syscall::ShmGetInfos, shm).into()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/uapi/uapi/syscall.rs
+++ b/uapi/uapi/syscall.rs
@@ -306,6 +306,7 @@ pub extern "C" fn sys_dma_get_stream_status(dmah: dmah_t) -> Status {
     syscall!(Syscall::DmaGetStreamStatus, dmah).into()
 }
 
+#[no_mangle]
 pub extern "C" fn sys_shm_get_infos(shm: shmh_t) -> Status {
     syscall!(Syscall::ShmGetInfos, shm).into()
 }

--- a/uapi/uapi/systypes.rs
+++ b/uapi/uapi/systypes.rs
@@ -88,6 +88,7 @@ pub enum Syscall {
     DmaStartStream,
     DmaStopStream,
     DmaGetStreamStatus,
+    ShmGetInfos,
 }
 }
 
@@ -484,3 +485,79 @@ pub type taskh_t = u32;
 pub type shmh_t = u32;
 #[allow(non_camel_case_types)]
 pub type dmah_t = u32;
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct shm_infos {
+    pub handle: shmh_t,
+    pub label: u32,
+    pub base: usize,
+    pub len: usize,
+    pub perms: u32,
+}
+
+#[test]
+fn test_layout_shm_infos() {
+    const UNINIT: ::std::mem::MaybeUninit<shm_infos> = ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
+    assert_eq!(
+        ::std::mem::size_of::<shm_infos>(),
+        32usize,
+        concat!("Size of: ", stringify!(shm_infos))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<shm_infos>(),
+        8usize,
+        concat!("Alignment of ", stringify!(shm_infos))
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((*ptr).handle) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(shm_infos),
+            "::",
+            stringify!(handle)
+        )
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((*ptr).label) as usize - ptr as usize },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(shm_infos),
+            "::",
+            stringify!(label)
+        )
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((*ptr).base) as usize - ptr as usize },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(shm_infos),
+            "::",
+            stringify!(base)
+        )
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((*ptr).len) as usize - ptr as usize },
+        16usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(shm_infos),
+            "::",
+            stringify!(len)
+        )
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((*ptr).perms) as usize - ptr as usize },
+        24usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(shm_infos),
+            "::",
+            stringify!(perms)
+        )
+    );
+}


### PR DESCRIPTION
When sharing a shared memory with another, it would be highly easier to be able to get back the SHM infos withtout requiring DTS forge with ninja.

The global problematic is defined in #39, which is fixed by this PR.

This PR also fixes an invalid glue addition of DMA-related entries at UAPI level versus gate LUT, which were not synchronize in term of syscall identifiers, making autotest failing for the new SHM syscall.
Note: all new syscalls are append to avoid any ABI violation.

Closes #39 