### PR TITLE
artifact: in autotest mode, add firmware.hex to install target

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -206,6 +206,8 @@ firmware_hex = custom_target(
         autotest_hex.full_path(), '-Intel',
     ],
     build_by_default: true,
+    install: true,
+    install_dir: get_option('bindir'),
 )
 else
 warning('srec_cat utility not found!')


### PR DESCRIPTION
the firmware.hex includes:
- sentry kernel bin
- idle bin
- autotest bin
So that it can be directly flashed on the corresponding HW target for auto testing (CD usage)