### PR TITLE
dma: building exchange api

### DIFF
--- a/autotest/src/tests/test_dma.c
+++ b/autotest/src/tests/test_dma.c
@@ -96,6 +96,20 @@ static void test_dma_assign_unassign_stream(dmah_t stream)
     TEST_END();
 }
 
+static void test_dma_start_n_wait_stream(dmah_t stream)
+{
+    Status res;
+    TEST_START();
+    res = sys_dma_assign_stream(stream);
+    ASSERT_EQ(res, STATUS_OK);
+    res = sys_dma_start_stream(stream);
+    ASSERT_EQ(res, STATUS_OK);
+    /* wait 50ms for DMA event, should rise in the meantime */
+    res = sys_wait_for_event(EVENT_TYPE_DMA, 50);
+    ASSERT_EQ(res, STATUS_OK);
+    TEST_END();
+}
+
 #endif
 
 void test_dma(void)
@@ -107,6 +121,7 @@ void test_dma(void)
     test_dma_get_handle_inval();
     test_dma_manipulate_stream_badhandle();
     test_dma_assign_unassign_stream(stream);
+    test_dma_start_n_wait_stream(stream);
     test_dma_start_stream(stream);
     test_dma_get_stream_status(stream);
     test_dma_stop_stream(stream);

--- a/kernel/include/bsp/drivers/dma/gpdma.h
+++ b/kernel/include/bsp/drivers/dma/gpdma.h
@@ -16,19 +16,15 @@
 
 #include <sentry/zlib/compiler.h>
 #include <dt-bindings/dma/stm32_dma.h>
+#include <uapi/types.h>
 
 /**
  * @brief generic state value definition for a DMA channel
+ *
+ * This enumerate aliasing UAPI to keep unified gpdma_ prefixed content at driver level
+ * @see dma_chan_state_t definition for corresponding content.
  */
-typedef enum gpdma_chan_state {
-    GPDMA_STATE_IDLE                    = 1, /**< DMA channel idle (not set or unused) */
-    GPDMA_STATE_RUNNING                 = 2, /**< DMA channel is running */
-    GPDMA_STATE_ABORTED                 = 3, /**< DMA stream aborted on SW request */
-    GPDMA_STATE_SUSPENDED               = 4, /**< DMA stream suspended on SW request*/
-    GPDMA_STATE_TRANSMISSION_FAILURE    = 5, /**< DMA transmission failure */
-    GPDMA_STATE_CONFIGURATION_FAILURE   = 6, /**< DMA channel configuration failure */
-    GPDMA_STATE_OVERRUN                 = 7, /**< DMA transmission overrun */
-} gpdma_chan_state_t;
+typedef dma_chan_state_t gpdma_chan_state_t;
 
 /**
  * @enum gpdma_chan_trigger

--- a/kernel/include/sentry/managers/dma.h
+++ b/kernel/include/sentry/managers/dma.h
@@ -14,6 +14,8 @@
 extern "C" {
 #endif
 
+#if CONFIG_HAS_GPDMA
+
 __STATIC_FORCEINLINE bool mgr_dma_is_irq_owned(int IRQn) {
     bool dma_owned = false;
 #ifdef CONFIG_HAS_GPDMA
@@ -23,6 +25,7 @@ return dma_owned;
 }
 
 kstatus_t mgr_dma_init(void);
+
 
 kstatus_t mgr_dma_watchdog(void);
 
@@ -37,6 +40,8 @@ kstatus_t mgr_dma_get_handle(uint32_t label, dmah_t * handle);
 kstatus_t mgr_dma_get_dmah_from_interrupt(uint16_t IRQn, dmah_t *dmah);
 
 kstatus_t mgr_dma_get_state(dmah_t d, dma_chan_state_t *state);
+
+#endif/* HAS_GPDMA */
 
 /**
  * Iterate over the device list, starting with id==id.

--- a/kernel/include/sentry/managers/dma.h
+++ b/kernel/include/sentry/managers/dma.h
@@ -36,6 +36,8 @@ kstatus_t mgr_dma_get_handle(uint32_t label, dmah_t * handle);
 
 kstatus_t mgr_dma_get_dmah_from_interrupt(uint16_t IRQn, dmah_t *dmah);
 
+kstatus_t mgr_dma_get_state(dmah_t d, dma_chan_state_t *state);
+
 /**
  * Iterate over the device list, starting with id==id.
  * Return the devinfo of the current id increment, or set devinfo to NULL and return K_ERROR_NOENT if

--- a/kernel/include/sentry/managers/task.h
+++ b/kernel/include/sentry/managers/task.h
@@ -181,6 +181,10 @@ taskh_t mgr_task_get_autotest(void);
 kstatus_t mgr_task_autotest(void);
 #endif
 
+#if CONFIG_HAS_GPDMA
+kstatus_t mgr_task_push_dma_event(taskh_t target, dmah_t dma_stream, dma_chan_state_t dma_event);
+#endif
+
 /* specialized event pushing API, do not use directly but instead Generic below */
 kstatus_t mgr_task_push_int_event(uint32_t IRQn, taskh_t dest);
 kstatus_t mgr_task_push_ipc_event(uint32_t len, taskh_t source, taskh_t dest);

--- a/kernel/include/sentry/managers/task.h
+++ b/kernel/include/sentry/managers/task.h
@@ -192,7 +192,7 @@ kstatus_t mgr_task_push_ipc_event(uint32_t len, taskh_t source, taskh_t dest);
 kstatus_t mgr_task_push_sig_event(uint32_t sig, taskh_t source, taskh_t dest);
 
 kstatus_t mgr_task_load_ipc_event(taskh_t context);
-kstatus_t mgr_task_load_sig_event(taskh_t context);
+kstatus_t mgr_task_load_sig_event(taskh_t context, uint32_t *signal, taskh_t *source);
 kstatus_t mgr_task_load_int_event(taskh_t context, uint32_t *IRQn);
 
 /* get back peer that has emitted IPC to owner, in iterative way

--- a/kernel/include/sentry/managers/task.h
+++ b/kernel/include/sentry/managers/task.h
@@ -183,6 +183,7 @@ kstatus_t mgr_task_autotest(void);
 
 #if CONFIG_HAS_GPDMA
 kstatus_t mgr_task_push_dma_event(taskh_t target, dmah_t dma_stream, dma_chan_state_t dma_event);
+kstatus_t mgr_task_load_dma_event(taskh_t target, dmah_t *dma_stream, dma_chan_state_t *dma_event);
 #endif
 
 /* specialized event pushing API, do not use directly but instead Generic below */
@@ -192,7 +193,7 @@ kstatus_t mgr_task_push_sig_event(uint32_t sig, taskh_t source, taskh_t dest);
 
 kstatus_t mgr_task_load_ipc_event(taskh_t context);
 kstatus_t mgr_task_load_sig_event(taskh_t context);
-kstatus_t mgr_task_load_int_event(taskh_t context);
+kstatus_t mgr_task_load_int_event(taskh_t context, uint32_t *IRQn);
 
 /* get back peer that has emitted IPC to owner, in iterative way
  * if status = K_STATUS_NOENT, no more IPC, if status = OKAY, peer hold the emitter handle

--- a/kernel/src/drivers/usart/stm32-lpuart.c
+++ b/kernel/src/drivers/usart/stm32-lpuart.c
@@ -11,6 +11,7 @@
  */
 
 #include <sentry/io.h>
+#include <bsp/drivers/clk/rcc.h>
 
 #include "lpuart_defs.h"
 #include "usart_priv.h"

--- a/kernel/src/managers/dma/dma.c
+++ b/kernel/src/managers/dma/dma.c
@@ -154,10 +154,10 @@ kstatus_t mgr_dma_get_state(dmah_t d, dma_chan_state_t *state)
     if (kdmah->streamid >= STREAM_LIST_SIZE) {
         goto end;
     }
-    if (stream_state[kdmah->streamid].handle != d) {
+    if (stream_config[kdmah->streamid].handle != d) {
         goto end;
     }
-    *state = stream_state[kdmah->streamid].status;
+    *state = stream_config[kdmah->streamid].status;
     status = K_STATUS_OKAY;
 end:
     return status;

--- a/kernel/src/managers/dma/dma.c
+++ b/kernel/src/managers/dma/dma.c
@@ -47,6 +47,7 @@ kstatus_t mgr_dma_init(void)
         /*@ assert \valid_read(stream_config[streamid].meta); */
         stream_config[streamid].handle = *dmah;
         stream_config[streamid].state = DMA_STREAM_STATE_UNSET; /** FIXME: define status types for streams */
+        stream_config[streamid].status = GPDMA_STATE_IDLE;
     }
 #endif
     return status;
@@ -136,6 +137,27 @@ kstatus_t mgr_dma_get_owner(dmah_t d, taskh_t *owner)
         goto end;
     }
     *owner = stream_config[kdmah->streamid].owner;
+    status = K_STATUS_OKAY;
+end:
+    return status;
+}
+
+/*@
+ * \requires valid(state);
+ */
+kstatus_t mgr_dma_get_state(dmah_t d, dma_chan_state_t *state)
+{
+    kstatus_t status = K_ERROR_INVPARAM;
+    /*@ assert \valid(state); */
+
+    kdmah_t const *kdmah = dmah_to_kdmah(&d);
+    if (kdmah->streamid >= STREAM_LIST_SIZE) {
+        goto end;
+    }
+    if (stream_state[kdmah->streamid].handle != d) {
+        goto end;
+    }
+    *state = stream_state[kdmah->streamid].status;
     status = K_STATUS_OKAY;
 end:
     return status;

--- a/kernel/src/managers/dma/dma.c
+++ b/kernel/src/managers/dma/dma.c
@@ -147,7 +147,7 @@ end:
 }
 
 /*@
- * \requires valid(state);
+   requires \valid(state);
  */
 kstatus_t mgr_dma_get_state(dmah_t d, dma_chan_state_t *state)
 {

--- a/kernel/src/managers/dma/dma.c
+++ b/kernel/src/managers/dma/dma.c
@@ -32,15 +32,19 @@ kstatus_t mgr_dma_init(void)
         /* Add entropy to handle initialization */
         if (unlikely(mgr_security_entropy_generate(&seed) != K_STATUS_OKAY)) {
             panic(PANIC_HARDWARE_INVALID_STATE);
+            __builtin_unreachable();
         }
         kdmah.reserved = seed;
 
         dmah_t const *dmah = kdmah_to_dmah(&kdmah);
         if (unlikely(dma_stream_get_meta(streamid, &stream_config[streamid].meta) != K_STATUS_OKAY)) {
             panic(PANIC_CONFIGURATION_MISMATCH);
+            __builtin_unreachable();
+
         }
         if (unlikely(mgr_task_get_handle(stream_config[streamid].meta->owner, &stream_config[streamid].owner) != K_STATUS_OKAY)) {
             panic(PANIC_CONFIGURATION_MISMATCH);
+            __builtin_unreachable();
         }
 
         /*@ assert \valid(dmah); */
@@ -200,6 +204,7 @@ kstatus_t mgr_dma_get_dmah_from_interrupt(const uint16_t IRQn, dmah_t *dmah)
         /*@ assert \valid_read(cfg); */
         if (unlikely(gpdma_get_interrupt(cfg, &stream_irqn) != K_STATUS_OKAY)) {
             panic(PANIC_CONFIGURATION_MISMATCH);
+            __builtin_unreachable();
         }
         if (stream_irqn == IRQn) {
             *dmah = stream_config[stream].handle;

--- a/kernel/src/managers/dma/dma.h
+++ b/kernel/src/managers/dma/dma.h
@@ -24,12 +24,14 @@ typedef enum dma_stream_state {
  *
  * This structure associate a hardware DMA stream configuration (dts-based) to
  * the stream owner (also dts-based, using associated channel owner)
+ *
  */
 typedef struct dma_stream_config {
     dma_meta_t const         * meta;   /**< Hardware configuration of the stream */
     dmah_t                     handle; /**< associated DMA handle (opaque format) */
     taskh_t                    owner;  /**< stream owner task handle */
-    dma_stream_state_t         state;  /**< DMA stream state */
+    dma_stream_state_t         state;  /**< DMA stream state (configuration relative state) */
+    dma_chan_state_t           status;  /**< DMA channel status, stream-relative dynamic */
 } dma_stream_config_t;
 
 

--- a/kernel/src/managers/task/task_core.c
+++ b/kernel/src/managers/task/task_core.c
@@ -476,7 +476,7 @@ kstatus_t mgr_task_push_int_event(uint32_t IRQn, taskh_t dest)
     /*@ assert \valid_read(kt); */
     task_t * tsk = task_get_from_handle(dest);
     job_state_t state;
-    if (unlikely((tsk->ints_head+1%TASK_EVENT_QUEUE_DEPTH) == tsk->ints_bottom)) {
+    if (unlikely(((tsk->ints_head+1)%TASK_EVENT_QUEUE_DEPTH) == tsk->ints_bottom)) {
         panic(PANIC_KERNEL_SHORTER_KBUFFERS_CONFIG);
         goto err;
     }
@@ -642,7 +642,7 @@ kstatus_t mgr_task_push_dma_event(taskh_t target, dmah_t dma_stream, dma_chan_st
         /*@ assert \false; */
         goto err;
     }
-    if (unlikely((tsk->dmas_head+1%TASK_EVENT_QUEUE_DEPTH) == tsk->dmas_bottom)) {
+    if (unlikely(((tsk->dmas_head+1)%TASK_EVENT_QUEUE_DEPTH) == tsk->dmas_bottom)) {
         panic(PANIC_KERNEL_SHORTER_KBUFFERS_CONFIG);
         goto err;
     }

--- a/kernel/src/managers/task/task_core.h
+++ b/kernel/src/managers/task/task_core.h
@@ -62,6 +62,7 @@ typedef struct tsk_gpdma_event_queue {
     uint32_t    event;  /**< DMA event to be pushed back to the userspace */
 } tsk_gpdma_event_queue_t;
 #endif
+static_assert(sizeof(tsk_gpdma_event_queue_t) == sizeof(uint64_t), "invalid structure size");
 
 
 typedef struct  task {

--- a/kernel/src/managers/task/task_core.h
+++ b/kernel/src/managers/task/task_core.h
@@ -100,9 +100,12 @@ typedef struct  task {
     uint32_t           ints[TASK_EVENT_QUEUE_DEPTH]; /**< List of IRQ events */
 #if CONFIG_HAS_GPDMA
     tsk_gpdma_event_queue_t  dmas[TASK_EVENT_QUEUE_DEPTH]; /**< List of DMA events */
-    uint8_t            num_dmas;
+    uint8_t            dmas_head;
+    uint8_t            dmas_bottom;
 #endif
-    uint8_t            num_ints;
+    uint8_t            ints_head;
+    uint8_t            ints_bottom;
+
     job_state_t     state;      /**< current task state */
     uint32_t        returncode;  /**< current task job return value, when exiting */
     secure_bool_t   sysretassigned; /**< a syscall has assigned a sysreturn */

--- a/kernel/src/managers/task/task_core.h
+++ b/kernel/src/managers/task/task_core.h
@@ -50,6 +50,20 @@ static inline const taskh_t *ktaskh_to_taskh(const ktaskh_t * const kth) {
     return converter.th;
 }
 
+#if CONFIG_HAS_GPDMA
+/** @struct queue of GPDMA input events
+ *
+ * @note the event field, being an enumerate, is kept fixed u32 size to avoid
+ * any compiler-specific size variation, keeping 64b size length whatever the
+ * compiler is.
+ */
+typedef struct tsk_gpdma_event_queue {
+    dmah_t      handle; /**< DMA stream handle associated to the event */
+    uint32_t    event;  /**< DMA event to be pushed back to the userspace */
+} tsk_gpdma_event_queue_t;
+#endif
+
+
 typedef struct  task {
     /* about task layouting */
     /** a task hold at most TASK_MAX_RESSOURCES_NUM regions (see memory.h backend)
@@ -84,8 +98,11 @@ typedef struct  task {
     uint32_t           ipcs[CONFIG_MAX_TASKS];       /**< List of IPCs event (one per peer task) */
     uint32_t           sigs[CONFIG_MAX_TASKS];       /**< List of SIGs event (one per peer task) */
     uint32_t           ints[TASK_EVENT_QUEUE_DEPTH]; /**< List of IRQ events */
+#if CONFIG_HAS_GPDMA
+    tsk_gpdma_event_queue_t  dmas[TASK_EVENT_QUEUE_DEPTH]; /**< List of DMA events */
+    uint8_t            num_dmas;
+#endif
     uint8_t            num_ints;
-
     job_state_t     state;      /**< current task state */
     uint32_t        returncode;  /**< current task job return value, when exiting */
     secure_bool_t   sysretassigned; /**< a syscall has assigned a sysreturn */

--- a/kernel/src/managers/task/task_core.h
+++ b/kernel/src/managers/task/task_core.h
@@ -61,9 +61,8 @@ typedef struct tsk_gpdma_event_queue {
     dmah_t      handle; /**< DMA stream handle associated to the event */
     uint32_t    event;  /**< DMA event to be pushed back to the userspace */
 } tsk_gpdma_event_queue_t;
-#endif
 static_assert(sizeof(tsk_gpdma_event_queue_t) == sizeof(uint64_t), "invalid structure size");
-
+#endif
 
 typedef struct  task {
     /* about task layouting */

--- a/kernel/src/syscalls/sysgate_waitforevent.c
+++ b/kernel/src/syscalls/sysgate_waitforevent.c
@@ -25,11 +25,24 @@ stack_frame_t *gate_waitforevent(stack_frame_t *frame,
     }
     /* and then irq... */
     if (mask & EVENT_TYPE_IRQ) {
-        if (mgr_task_load_int_event(current) == K_STATUS_OKAY) {
+        uint32_t irqn;
+        if (mgr_task_load_int_event(current, &irqn) == K_STATUS_OKAY) {
+            /* TODO: copy IRQn to user */
             mgr_task_set_sysreturn(current, STATUS_OK);
             goto end;
         }
     }
+#if CONFIG_HAS_GPDMA
+    if (mask & EVENT_TYPE_DMA) {
+        dmah_t dmah;
+        dma_chan_state_t event;
+        if (mgr_task_load_dma_event(current, &dmah, &event) == K_STATUS_OKAY) {
+            /* TODO: copy handle  to user */
+            mgr_task_set_sysreturn(current, STATUS_OK);
+            goto end;
+        }
+    }
+#endif
     /* and then ipc... */
     if (mask & EVENT_TYPE_IPC) {
         if (mgr_task_load_ipc_event(current) == K_STATUS_OKAY) {

--- a/kernel/src/syscalls/sysgate_waitforevent.c
+++ b/kernel/src/syscalls/sysgate_waitforevent.c
@@ -18,8 +18,11 @@ static inline void gate_waitforevent_populate_dma(taskh_t current, dmah_t dma, d
         /* this should never happen !*/
         /*@ assert \false; */
         panic(PANIC_KERNEL_INVALID_MANAGER_RESPONSE);
+        __builtin_unreachable();
     }
+    /*@ assert \valid_read(meta); */
     svc = task_get_svcexchange(meta);
+    /*@ assert \valid(svc); */
     dest_svcexch = (exchange_event_t*)svc;
     /* set T,L values from TLV */
     dest_svcexch->type = EVENT_TYPE_DMA;
@@ -43,8 +46,11 @@ static inline void gate_waitforevent_populate_signal(taskh_t current, uint8_t si
         /* this should never happen !*/
         /*@ assert \false; */
         panic(PANIC_KERNEL_INVALID_MANAGER_RESPONSE);
+        __builtin_unreachable();
     }
+    /*@ assert \valid_read(meta); */
     svc = task_get_svcexchange(meta);
+    /*@ assert \valid(svc); */
     dest_svcexch = (exchange_event_t*)svc;
     /* set T,L values from TLV */
     dest_svcexch->type = EVENT_TYPE_SIGNAL;

--- a/kernel/src/syscalls/sysgate_waitforevent.c
+++ b/kernel/src/syscalls/sysgate_waitforevent.c
@@ -8,6 +8,54 @@
 #include <uapi/types.h>
 
 
+static inline void gate_waitforevent_populate_dma(taskh_t current, dmah_t dma, dma_chan_state_t event)
+{
+    task_meta_t const *meta;
+    uint8_t *svc;
+    exchange_event_t *dest_svcexch;
+    /* forge SVC exchange with received signal informations */
+    if (unlikely(mgr_task_get_metadata(current, &meta) != K_STATUS_OKAY)) {
+        /* this should never happen !*/
+        /*@ assert \false; */
+        panic(PANIC_KERNEL_INVALID_MANAGER_RESPONSE);
+    }
+    svc = task_get_svcexchange(meta);
+    dest_svcexch = (exchange_event_t*)svc;
+    /* set T,L values from TLV */
+    dest_svcexch->type = EVENT_TYPE_DMA;
+    dest_svcexch->length = sizeof(uint8_t);
+    dest_svcexch->magic = 0x4242; /** FIXME: define a magic shared with uapi */
+    dest_svcexch->source = dma; /**< stream source of event */
+    /* here, event is encoded on 8bits length */
+    dest_svcexch->data[0] = event;
+}
+
+/**
+ * @fn gate_waitforevent_populate_signal : populate svc exchange with signal info
+ */
+static inline void gate_waitforevent_populate_signal(taskh_t current, uint8_t sig, taskh_t source)
+{
+    task_meta_t const *meta;
+    uint8_t *svc;
+    exchange_event_t *dest_svcexch;
+    /* forge SVC exchange with received signal informations */
+    if (unlikely(mgr_task_get_metadata(current, &meta) != K_STATUS_OKAY)) {
+        /* this should never happen !*/
+        /*@ assert \false; */
+        panic(PANIC_KERNEL_INVALID_MANAGER_RESPONSE);
+    }
+    svc = task_get_svcexchange(meta);
+    dest_svcexch = (exchange_event_t*)svc;
+    /* set T,L values from TLV */
+    dest_svcexch->type = EVENT_TYPE_SIGNAL;
+    dest_svcexch->length = sizeof(uint32_t);
+    dest_svcexch->magic = 0x4242; /** FIXME: define a magic shared with uapi */
+    dest_svcexch->source = source;
+    uint32_t *sigdata = (uint32_t*)&dest_svcexch->data;
+    sigdata[0] = sig;
+
+}
+
 stack_frame_t *gate_waitforevent(stack_frame_t *frame,
                                uint8_t          mask,
                                int32_t          timeout)
@@ -21,22 +69,7 @@ stack_frame_t *gate_waitforevent(stack_frame_t *frame,
         uint32_t sig;
         taskh_t source;
         if (mgr_task_load_sig_event(current, &sig, &source) == K_STATUS_OKAY) {
-            task_meta_t const *meta;
-            uint8_t *svc;
-            exchange_event_t *dest_svcexch;
-
-            /* forge SVC exchange with received signal informations */
-            mgr_task_get_metadata(current, &meta);
-            svc = task_get_svcexchange(meta);
-            dest_svcexch = (exchange_event_t*)svc;
-            /* set T,L values from TLV */
-            dest_svcexch->type = EVENT_TYPE_SIGNAL;
-            dest_svcexch->length = sizeof(uint32_t);
-            dest_svcexch->magic = 0x4242; /** FIXME: define a magic shared with uapi */
-            dest_svcexch->source = source;
-            uint32_t *sigdata = (uint32_t*)&dest_svcexch->data;
-            sigdata[0] = sig;
-
+            gate_waitforevent_populate_signal(current, sig, source),
             mgr_task_set_sysreturn(current, STATUS_OK);
             goto end;
         }
@@ -55,21 +88,7 @@ stack_frame_t *gate_waitforevent(stack_frame_t *frame,
         dmah_t dmah;
         dma_chan_state_t event;
         if (mgr_task_load_dma_event(current, &dmah, &event) == K_STATUS_OKAY) {
-            task_meta_t const *meta;
-            uint8_t *svc;
-            exchange_event_t *dest_svcexch;
-
-            /* forge SVC exchange with received signal informations */
-            mgr_task_get_metadata(current, &meta);
-            svc = task_get_svcexchange(meta);
-            dest_svcexch = (exchange_event_t*)svc;
-            /* set T,L values from TLV */
-            dest_svcexch->type = EVENT_TYPE_DMA;
-            dest_svcexch->length = sizeof(uint32_t);
-            dest_svcexch->magic = 0x4242; /** FIXME: define a magic shared with uapi */
-            dest_svcexch->source = dmah; /**< stream source of event */
-            /* here, event is encoded on 8bits length */
-            dest_svcexch->data[0] = event;
+            gate_waitforevent_populate_dma(current, dmah, event);
             mgr_task_set_sysreturn(current, STATUS_OK);
             goto end;
         }

--- a/uapi/include/uapi/types.h
+++ b/uapi/include/uapi/types.h
@@ -43,7 +43,8 @@ typedef enum EventType {
   EVENT_TYPE_IPC = 1,
   EVENT_TYPE_SIGNAL = 2,
   EVENT_TYPE_IRQ = 4,
-  EVENT_TYPE_ALL = 7,
+  EVENT_TYPE_DMA = 8,
+  EVENT_TYPE_ALL = 15,
 } EventType;
 
 typedef enum Precision {

--- a/uapi/include/uapi/types.h
+++ b/uapi/include/uapi/types.h
@@ -303,6 +303,22 @@ typedef struct shm_infos {
     uint32_t perms;   /*< SHM permissions (mask of SHMPermission) */
 } shm_infos_t;
 
+/**
+ * @brief generic state value definition for a DMA stream, used to get back DMA statuses
+ */
+typedef enum dma_chan_state {
+    GPDMA_STATE_IDLE                    = 1, /**< DMA channel idle (not set or unused) */
+    GPDMA_STATE_RUNNING                 = 2, /**< DMA channel is running */
+    GPDMA_STATE_ABORTED                 = 3, /**< DMA stream aborted on SW request */
+    GPDMA_STATE_SUSPENDED               = 4, /**< DMA stream suspended on SW request*/
+    GPDMA_STATE_TRANSMISSION_FAILURE    = 5, /**< DMA transmission failure */
+    GPDMA_STATE_CONFIGURATION_FAILURE   = 6, /**< DMA channel configuration failure */
+    GPDMA_STATE_OVERRUN                 = 7, /**< DMA transmission overrun */
+    GPDMA_STATE_TRANSFER_COMPLETE       = 8, /**< DMA transfer complete for this channel */
+    GPDMA_STATE_HALF_TRANSFER           = 9, /**< DMA transfer half-complete for this channel */
+} dma_chan_state_t;
+
+
 #ifdef __cplusplus
 } /* extern "C" */
 #endif // __cplusplus

--- a/uapi/uapi/systypes.rs
+++ b/uapi/uapi/systypes.rs
@@ -196,17 +196,19 @@ pub enum EventType {
     Ipc = 1,
     Signal = 2,
     Irq = 4,
-    All = 7,
+    Dma = 8,
+    All = 15,
 }
 
 impl From<EventType> for u32 {
     fn from(event: EventType) -> u32 {
         match event {
-            EventType::None => 0x0,
-            EventType::Ipc => 0x1,
-            EventType::Signal => 0x2,
-            EventType::Irq => 0x4,
-            EventType::All => 0x7,
+            EventType::None => 0,
+            EventType::Ipc => 1,
+            EventType::Signal => 2,
+            EventType::Irq => 4,
+            EventType::Dma => 8,
+            EventType::All => 15,
         }
     }
 }


### PR DESCRIPTION
As defined in DMA wiki, adding a new event queue specific to DMA streams vents.
As DMA streams events are specific, consolidated, events types, they should be pushed up to userspace tasks as such, instead of pushing bare IRQn.
Bare IRQn are useless to userspace, as DMA IRQ acknowledge is under the kernel control. Instead pushing consolidated event is useful for user task, as they can directly manipulate such event for functional implementation.

A DMA event is then received as a specific event of the `wait_for_event()` syscall. In that case, the event received looks like the following tuple:
```
typedef enum dma_chan_state {
    GPDMA_STATE_IDLE                    = 1, /**< DMA channel idle (not set or unused) */
    GPDMA_STATE_RUNNING                 = 2, /**< DMA channel is running */
    GPDMA_STATE_ABORTED                 = 3, /**< DMA stream aborted on SW request */
    GPDMA_STATE_SUSPENDED               = 4, /**< DMA stream suspended on SW request*/
    GPDMA_STATE_TRANSMISSION_FAILURE    = 5, /**< DMA transmission failure */
    GPDMA_STATE_CONFIGURATION_FAILURE   = 6, /**< DMA channel configuration failure */
    GPDMA_STATE_OVERRUN                 = 7, /**< DMA transmission overrun */
    GPDMA_STATE_TRANSFER_COMPLETE       = 8, /**< DMA transfer complete for this channel */
    GPDMA_STATE_HALF_TRANSFER           = 9, /**< DMA transfer half-complete for this channel */
} dma_chan_state_t;

{ dma_handle, dma_event_state }
```
This tuple allows to directly associate the handle with a userspace context, and the DMA event type used to react to various events as required.

The DMA event structure pushed by the kernel is the following, respecting the exchange_event_t standard Sentry header:

```c
{
    header.type = EVENT_TYPE_DMA, 
    header.length = 1, /* 1 data byte: the DMA event type */
    header.magic = 0x4242, /* hardcoded by now */
    header.source = dma_stream_handle,
    header.data[0] = dma_stream_event;  
}
```

This allows such a usage:

```c
uint8_t dma_event_buf[sizeof(exchange_event_t)+sizeof(uint8_t)];

sys_dma_start(dmah);
if (sys_wait_for_event(EVENT_TYPE_DMA, WAIT_FOREVER) == STATUS_OKAY) {
     copy_to_user(dma_event_buf, sizeof(exchange_event_t)+sizeof(uint8_t));

    /* manipulate dma event info locally */
    exchange_event_t *event = &dma_event_buf[0];
    printf("dma event %d, from handle %lx\n", event->data[0], event->source);
    switch (event->data[0]) {
      case GPDMA_STATE_TRANSMISSION_FAILURE:
        //
      case GPDMA_STATE_USER_FAILURE:
       //
      case GPDMA_STATE_TRANSFER_COMPLETE:
       //
    }
}
```

- [x] push DMA event type to uapi types.h header
- [x] add support for DMA event queue in task context
- [x] add support for DMA event queue push interface
- [x] make DMA IRQn handler pushing the event to the corresponding stream owner
- [x] Add DMA event to the `wait_for_event()` events list
- [x] add support for DMA event pull interface from task context
- [x] add support for DMA event at `wait_for_event()` syscall level
- [x] update autotest to support this new API

depends on #44 
closes #60
