### PR TITLE
support/meson/version: fix case where there is no tags

### DIFF
--- a/support/meson/version.sh
+++ b/support/meson/version.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 
-# SPDX-FileCopyrightText: 2023 Ledger SAS
+# SPDX-FileCopyrightText: 2023 - 2024 Ledger SAS
 # SPDX-License-Identifier: Apache-2.0
 
 if [ "$1" = "get-vcs" ]; then

--- a/support/meson/version.sh
+++ b/support/meson/version.sh
@@ -3,11 +3,10 @@
 # SPDX-FileCopyrightText: 2023 Ledger SAS
 # SPDX-License-Identifier: Apache-2.0
 
-
 if [ "$1" = "get-vcs" ]; then
-  git -C "$MESON_SOURCE_ROOT" describe --tags --dirty
+    git -C "$MESON_SOURCE_ROOT" describe --tags --dirty --always
 elif [ "$1" = "set-dist" ]; then
-  $MESONREWRITE --sourcedir="$MESON_PROJECT_DIST_ROOT" kwargs set project / version "$2"
+    $MESONREWRITE --sourcedir="$MESON_PROJECT_DIST_ROOT" kwargs set project / version "$2"
 else
-  exit 1
+    exit 1
 fi


### PR DESCRIPTION
If there is no tags (which happens with personal fork for instance), `version.sh` will fail.
This PR allows to forge a simple version string in case there is no tags (yet) corresponding to short commit ID.

