### PR TITLE
fix: fixing EINTR usage for early termination of waitforevent()

### DIFF
--- a/kernel/src/syscalls/sysgate_waitforevent.c
+++ b/kernel/src/syscalls/sysgate_waitforevent.c
@@ -85,12 +85,7 @@ stack_frame_t *gate_waitforevent(stack_frame_t *frame,
     if (mask & EVENT_TYPE_IRQ) {
         uint32_t irqn;
         if (mgr_task_load_int_event(current, &irqn) == K_STATUS_OKAY) {
-            /* TODO: copy IRQn to user */
-            if (timeout >= 0) {
-                mgr_task_set_sysreturn(current, STATUS_INTR);
-            } else {
-                mgr_task_set_sysreturn(current, STATUS_OK);
-            }
+            mgr_task_set_sysreturn(current, STATUS_OK);
             goto end;
         }
     }
@@ -100,11 +95,7 @@ stack_frame_t *gate_waitforevent(stack_frame_t *frame,
         gpdma_chan_state_t event;
         if (mgr_task_load_dma_event(current, &dmah, &event) == K_STATUS_OKAY) {
             gate_waitforevent_populate_dma(current, dmah, event);
-            if (timeout >= 0) {
-                mgr_task_set_sysreturn(current, STATUS_INTR);
-            } else {
-                mgr_task_set_sysreturn(current, STATUS_OK);
-            }
+            mgr_task_set_sysreturn(current, STATUS_OK);
             goto end;
         }
     }
@@ -112,11 +103,7 @@ stack_frame_t *gate_waitforevent(stack_frame_t *frame,
     /* and then ipc... */
     if (mask & EVENT_TYPE_IPC) {
         if (mgr_task_load_ipc_event(current) == K_STATUS_OKAY) {
-            if (timeout >= 0) {
-                mgr_task_set_sysreturn(current, STATUS_INTR);
-            } else {
-                mgr_task_set_sysreturn(current, STATUS_OK);
-            }
+            mgr_task_set_sysreturn(current, STATUS_OK);
             goto end;
         }
     }


### PR DESCRIPTION
The way the wait_for_event() gate behaves is invalid, as it returns a STATUS_INTR when the syscall returns before its timeout definition when finding an input event.
The semantic of STATUS_INTR is not made for such a behavior, as it is made to requires from the caller to reexecute the syscall immediatly due to a interrupted function call (typically when a signal generated an interruption).
In our API, returning previously **because** there is input data should return a STATUS_OK instead.