### PR TITLE
doc: update README, adding contribution and conduct standard files

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -3,6 +3,9 @@
 
 changelog:
   categories:
+    - title: Vulnerability fixes
+      labels:
+        - "cve"
     - title: Breaking Changes
       labels:
         - abi-evolution

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,138 @@
+<!--
+SPDX-FileCopyrightText: 2024 Leger SAS
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Contributor Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders at outpost-os@ledger.fr.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+The only changes made by The Outpost Project to the original document were to
+make explicit the mail of the recipients of Code of Conduct incident reports.
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ collaboratibe methods for submissions.
   ensure developers are following licensing criteria for their
   contributions, and documented with a ``Signed-off-by`` line in commits.
 
-* Sentry kernel development workflow is supported on Linux, macOS, and Windows. Windows workflow.
+* Sentry kernel development workflow is supported on Linux, macOS, and Windows.
 
 * Source code for the project is maintained in the GitHub repo:
   https://github.com/outpost-os/sentry-kernel

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,61 @@
+<!--
+SPDX-FileCopyrightText: 2023-2024 Ledger SAS
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Contribution Guidelines
+
+Being an open-source project, we encourage the community to submit patches and issues
+directly to the project.
+This project is made to be collaborative, and we appreciate the usage of standards and
+collaboratibe methods for submissions.
+
+## To begin with:
+
+* Sentry kernel uses the permissive `Apache 2.0 license`, that allows gree use, dmofication
+  and redistribution of any project using this kernel.
+
+* The Sentry kernel uses SPDX standard for license declaration. The usage of Reuse is used
+  in order to validate that all project peaces properly specify the according license.
+
+* The Developer Certificate of Origin (DCO) process is followed to
+  ensure developers are following licensing criteria for their
+  contributions, and documented with a ``Signed-off-by`` line in commits.
+
+* Sentry kernel development workflow is supported on Linux, macOS, and Windows. Windows workflow.
+
+* Source code for the project is maintained in the GitHub repo:
+  https://github.com/outpost-os/sentry-kernel
+
+* Issues, features and security tracking is done with Github issues, pull-requests and security reports.
+  Milestones are used in order to define a clearer roadmap.
+
+* A Continuous Integration (CI) system runs on every Pull Request (PR). This includes the formal proofness (noRTE) analysis.
+
+* A Discord channel denoted OutpostOS is dedicated to exchanges with the community. This repository also has the Github
+  discussions interface active for any questions or requests.
+
+## Contribution buidelines
+
+The following guidelines must be respected by all contributors:
+
+* When contributing, please use the ususal fork+pull-request Github model.
+
+* When publishing a bug through issues, please specify properly the use case and a way de reproduce.
+
+* When proposing a feature, be sure to properly define the usage, and ensure that the according documentation in the `doc/concepts` is properly made.
+  If the feature includes a new or updated syscall, consider adding its full description respecting the usual man format chapters in
+  the `docs/concepts/uapi/syscalls` directory, so that corresponding man page will be generated.
+
+* By now, as the kernel implementation is in early stage, PRs should target the `main` branch.
+
+* If a contribution requires a large amount of code, please decompose in multiple consecutive pull-requests, to make PR review easier.
+
+* All pull-request will be checked for non-regression using the kernel *autotest* build profile, that include a dedicated Autotest application stored in
+  this very repository. No regression is allowed.
+
+* All modified file must have the SPDX header copyright line updated with the PR author. All new file must have a proper SPDX header (checked by CI).
+
+* Please avoid adding new external dependencies. Dependabot is used for dependency analysis but their number should stay small enough.
+
+* When publising a vulnerability fix, the PR title **must** start with `cve:` tag and be dedicated to CVE fix.

--- a/README.md
+++ b/README.md
@@ -3,15 +3,7 @@ SPDX-FileCopyrightText: 2023-2024 Ledger SAS
 SPDX-License-Identifier: Apache-2.0
 -->
 
-.. raw:: html
-
-   <a href="https://outpost-sentry.readthedocs.io/en/latest/index.html">
-     <p align="center">
-       <picture>
-         <img src="https://outpost-sentry.readthedocs.io/en/latest/_images/sentry_kernel.png">
-       </picture>
-     </p>
-   </a>
+![sentry logo](https://outpost-sentry.readthedocs.io/en/latest/_images/sentry_kernel.png)
 
 # About
 

--- a/README.md
+++ b/README.md
@@ -2,11 +2,18 @@
 SPDX-FileCopyrightText: 2023-2024 Ledger SAS
 SPDX-License-Identifier: Apache-2.0
 -->
-# Sentry kernel implementation
 
+.. raw:: html
 
-## Current project state
+   <a href="https://outpost-sentry.readthedocs.io/en/latest/index.html">
+     <p align="center">
+       <picture>
+         <img src="https://outpost-sentry.readthedocs.io/en/latest/_images/sentry_kernel.png">
+       </picture>
+     </p>
+   </a>
 
+# About
 
 ![GNU/Linux build](https://github.com/outpost-os/sentry-kernel/actions/workflows/gnulinux.yml/badge.svg)
 ![MacOS X build](https://github.com/outpost-os/sentry-kernel/actions/workflows/macos.yml/badge.svg)
@@ -16,10 +23,9 @@ SPDX-License-Identifier: Apache-2.0
 ![GitHub License](https://img.shields.io/github/license/outpost-os/sentry-kernel)
 [![REUSE status](https://api.reuse.software/badge/github.com/outpost-os/sentry-kernel)](https://api.reuse.software/info/github.com/outpost-os/sentry-kernel)
 
+The Sentry kernel is a high security level micro-kernel implementation made for high security embedded systems that include micro-controllers in association with dedicated Secure Element component for security cryptographic functions.
 
-## About
-
-This is the repository of the Sentry kernel
+Complete Sentry documentation is published on [readthedocs](https://outpost-sentry.readthedocs.io/en/latest/index.html).
 
 Sentry kernel uses [The Meson Build System](https://mesonbuild.com/).
 


### PR DESCRIPTION
* Adding abstract definition of Sentry and link the doc in the README file
* Adding a CONTIBUTIONS guideline file
* Adding a CODE_OF_CONDUCT file based on the codecovenant standard file