### PR TITLE
security: adding high level security flags

### DIFF
--- a/dts/examples/nucleo_u5a5_autotest.dts
+++ b/dts/examples/nucleo_u5a5_autotest.dts
@@ -31,8 +31,8 @@
 
 /{
 	reserved-memory {
-		autotest_code: autotest_code@800a000 {
-			reg = <0x800a000 0xe000>;
+		autotest_code: autotest_code@800d000 {
+			reg = <0x800d000 0xe000>;
 			compatible = "outpost,memory-pool";
 		};
 

--- a/dts/examples/stm32f429i_disc1_autotest.dts
+++ b/dts/examples/stm32f429i_disc1_autotest.dts
@@ -18,8 +18,8 @@
 	};
 
 	reserved-memory {
-		autotest_code: autotest_code@800a000 {
-			reg = <0x800c000 0xe000>;
+		autotest_code: autotest_code@800d000 {
+			reg = <0x800d000 0xe000>;
 			compatible = "outpost,memory-pool";
 		};
 

--- a/dts/sentry.dtsi
+++ b/dts/sentry.dtsi
@@ -17,12 +17,12 @@
 		#size-cells = <1>;
 
 		kernel_code: kernel_code@8000000 {
-			reg = <0x8000000 0x8000>;
+			reg = <0x8000000 0xb000>;
 			compatible = "outpost,memory-pool";
 		};
 
-		idle_code: idle_code@8008000 {
-			reg = <0x8008000 0x300>;
+		idle_code: idle_code@800c000 {
+			reg = <0x800c000 0x300>;
 			compatible = "outpost,memory-pool";
 		};
 

--- a/meson.build
+++ b/meson.build
@@ -30,6 +30,27 @@ project('sentry-kernel', 'c',
 
 meson.add_dist_script('support/meson/version.sh', 'set-dist', meson.project_version())
 
+# Testing high security flags of cross compiler. These are gcc 13-14 hardening flags.
+# See https://gcc.gnu.org/onlinedocs/gcc-14.1.0/gcc/Instrumentation-Options.html#index-fharden-compares
+# for more information about each flag
+hardening_cflags = [
+  '-fharden-compares',
+  '-fharden-conditional-branches',
+  '-fharden-control-flow-redundancy',
+  '-fhardcfr-check-returning-calls',
+  '-fstack-clash-protection',
+]
+activated_hardening_cflags = []
+
+compiler = meson.get_compiler('c', native: false)
+
+foreach cflag: hardening_cflags
+  if compiler.has_argument(cflag)
+    activated_hardening_cflags += cflag
+  endif
+endforeach
+
+
 objcopy = find_program('objcopy')
 sentry_install_script = find_program('support/scripts/install.py')
 
@@ -63,6 +84,9 @@ global_build_args = [
     '-Wno-unused-variable', # FIXME: while in early dev
     '-Wno-unused-parameter', # FIXME: while in early dev
 ]
+
+# adding supported hardened build args
+global_build_args += activated_hardening_cflags
 
 # Deprecated kconfig entry handling, to be removed on next major release
 if kconfig_data.has('CONFIG_TASK_MAGIC_VALUE')
@@ -175,6 +199,7 @@ summary(
         'soc': kconfig_data.get_unquoted('CONFIG_ARCH_SOCNAME').to_lower(),
         'build mode': build_mode,
         'standalone': is_standalone,
+        'hardening flags': activated_hardening_cflags,
     },
     bool_yn: true,
     section: 'Configuration'


### PR DESCRIPTION
Adding gcc high level security flags that increase various types of attacks such as control flow checks and redundancy, return code increased validation, etc.

Note: this PR increase the kernel footprint (approx ~9kB at the time of this PR), and thus may need to be Kconfig based. This will be made in a separated PR that cleanup the hardening part of the kernel in a dedicated Kconfig section.