### PR TITLE
kconfig: Using Kconfig as global hardening selector

### DIFF
--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -64,3 +64,68 @@ config WITH_JTAG_CONNECTED
 	depends on BUILD_TARGET_DEBUG || BUILD_TARGET_AUTOTEST
 
 endmenu
+
+menu "Kernel security"
+
+# symbols selected by build mode
+config SECU_SSP_USER
+	bool
+	# support for user threads stack canaries
+
+config SECU_SSP_KERN
+	bool
+	# support for kernel threads stack canaries
+
+config SECU_HW_SETNCHECK
+	bool
+	---help---
+	  when possible (may depend on the hardware device), double verify that
+	  the target register configuration is valid and active
+	# Unable set and check of critical hardware registers
+	# (iowrite + ioread and compare)
+
+config SECU_NO_WEAKTYPES
+	bool
+	---help---
+	  Comparison to 0 lead to potential weak optimizations that should be
+	  avoided in security critical environment. In the same way, hamming distance
+	  of 1 can be easily faulted, in comparison with a discrete type.
+	  This is done by using secure_bool_t type and by activating (gcc>=14)
+
+config SECU_TASK_INTEGRITY_AT_BOOT
+	bool
+
+config SECU_ENFORCE_COMPARE
+	bool "Enforce comparison checks by compiler"
+	default y
+	---help---
+	  All variable comparison and conditional branch related comparison are
+	  hardened using the `harden-compares` and `harden-conditional-branches`
+	  hardening flags (gcc>=13)
+
+config SECU_ENFORCE_CFI
+	bool "Harden control flow redundancy"
+	default n
+	---help---
+	  Emit extra code to set booleans when entering basic blocks, and to verify
+	  and trap, at function exits, when the booleans do not form an execution
+	  path that is compatible with the control flow graph.
+
+config SECU_ENFORCE_RETURNING_CALLS
+	depends on SECU_ENFORCE_CFI
+	default y
+	bool "Enforce return-time control flow"
+	---help---
+	  Harden return time checks, including noreturn invalid behavior, using
+	  -fhardcfr-check-returning-calls and -fhardcfr-check-noreturn-calls=always flags
+	  (gcc>=14)
+
+config SECU_ENFORCE_FAULT_INJECTION
+	bool "Enforce fault injection projections"
+	---help---
+	  Enable this flag to enforce formally proven execution
+	  paths with supplementary checks that whould have been dead
+	  code in nominal execution
+
+
+endmenu

--- a/kernel/src/managers/Kconfig
+++ b/kernel/src/managers/Kconfig
@@ -135,43 +135,16 @@ endif
 
 menu "Security manager"
 
-# symbols selected by build mode
-config SECU_SSP_USER
-	bool
-	# support for user threads stack canaries
-
-config SECU_SSP_KERN
-	bool
-	# support for kernel threads stack canaries
-
-config SECU_HW_SETNCHECK
-	bool
-	---help---
-	  when possible (may depend on the hardware device), double verify that
-	  the target register configuration is valid and active
-	# Unable set and check of critical hardware registers
-	# (iowrite + ioread and compare)
-
-config SECU_NO_WEAKTYPES
-	bool
-	---help---
-	  Comparison to 0 lead to potential weak optimizations that should be
-	  avoided in security critical environment. In the same way, hamming distance
-	  of 1 can be easily faulted, in comparison with a discrete type
-
-config SECU_LOOP_DBLE_IDX
-	bool
-	# Double index count and check in critical loops
-
-config SECU_TASK_INTEGRITY_AT_BOOT
-	bool
-
-config SECU_ENFORCE_FAULT_INJECTION
-	bool "Enforce fault injection projections"
-	---help---
-	  Enable this flag to enforce formally proven execution
-	  paths with supplementary checks that whould have been dead
-	  code in nominal execution
+choice
+	bool "Entropy source"
+	default SECURITY_HW_ENTROPY if HAS_RNG
+	default SECURITY_PGC32_ENTROPY if !HAS_RNG
+	config SECURITY_HW_ENTROPY
+		bool "Using HW RNG as entropy source"
+		depends on HAS_RNG
+	config SECURITY_PGC32_ENTROPY
+		bool "Using PGC32 as entropy source"
+endchoice
 
 endmenu
 

--- a/kernel/src/managers/security/entropy.c
+++ b/kernel/src/managers/security/entropy.c
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <stddef.h>
-#if defined(CONFIG_HAS_RNG)
+#if defined(CONFIG_SECURITY_HW_ENTROPY)
 #include <bsp/drivers/rng/rng.h>
 #endif
 #include <sentry/zlib/crypto.h>
@@ -25,7 +25,7 @@ static uint32_t seed;
 kstatus_t mgr_security_entropy_init(void)
 {
     kstatus_t status;
-#if !defined(CONFIG_HAS_RNG)
+#if !defined(CONFIG_SECURITY_HW_ENTROPY)
     pr_warn("HW RNG not supported, initializing SW entropy backend.");
     /* Here we use PGC32 has this is the lonely function we have to generate random
      sequence in SW mode. To be replaced by another pseudo-random (or higher security
@@ -65,7 +65,7 @@ kstatus_t mgr_security_entropy_generate(uint32_t *seed)
     if (unlikely(seed == NULL)) {
         goto end;
     }
-#if CONFIG_HAS_RNG
+#if CONFIG_SECURITY_HW_ENTROPY
     status = rng_get(seed);
 #else
     *seed = pcg32();

--- a/meson.build
+++ b/meson.build
@@ -30,26 +30,7 @@ project('sentry-kernel', 'c',
 
 meson.add_dist_script('support/meson/version.sh', 'set-dist', meson.project_version())
 
-# Testing high security flags of cross compiler. These are gcc 13-14 hardening flags.
-# See https://gcc.gnu.org/onlinedocs/gcc-14.1.0/gcc/Instrumentation-Options.html#index-fharden-compares
-# for more information about each flag
-hardening_cflags = [
-  '-fharden-compares',
-  '-fharden-conditional-branches',
-  '-fharden-control-flow-redundancy',
-  '-fhardcfr-check-returning-calls',
-  '-fstack-clash-protection',
-]
-activated_hardening_cflags = []
-
 compiler = meson.get_compiler('c', native: false)
-
-foreach cflag: hardening_cflags
-  if compiler.has_argument(cflag)
-    activated_hardening_cflags += cflag
-  endif
-endforeach
-
 
 objcopy = find_program('objcopy')
 sentry_install_script = find_program('support/scripts/install.py')
@@ -69,6 +50,39 @@ kconfig_h = kconfig_proj.get_variable('kconfig_h')
 kconfig_rustargs = kconfig_proj.get_variable('kconfig_rustargs')
 kconfig_data = kconfig_proj.get_variable('kconfig_data')
 
+# Testing high security flags of cross compiler. These are gcc 13-14 hardening flags.
+# See https://gcc.gnu.org/onlinedocs/gcc-14.1.0/gcc/Instrumentation-Options.html#index-fharden-compares
+# for more information about each flag
+activated_hardening_cflags = []
+hardening_cflags = [
+    '-fstack-clash-protection',
+]
+
+if kconfig_data.get('CONFIG_SECU_ENFORCE_COMPARE', 0) == 1
+hardening_cflags += [
+  '-fharden-compares',
+  '-fharden-conditional-branches',
+]
+endif
+
+if kconfig_data.get('CONFIG_SECU_ENFORCE_CFI', 0) == 1
+hardening_cflags += [
+  '-fharden-control-flow-redundancy',
+]
+endif
+
+if kconfig_data.get('CONFIG_SECU_ENFORCE_RETURNING_CALLS', 0) == 1
+hardening_cflags += [
+  '-fhardcfr-check-returning-calls',
+]
+endif
+
+foreach cflag: hardening_cflags
+  if compiler.has_argument(cflag)
+    activated_hardening_cflags += cflag
+  endif
+endforeach
+
 external_deps = []
 
 global_build_args = [
@@ -83,10 +97,8 @@ global_build_args = [
     '-Wno-unused-function', # FIXME: while in early dev
     '-Wno-unused-variable', # FIXME: while in early dev
     '-Wno-unused-parameter', # FIXME: while in early dev
+    activated_hardening_cflags,
 ]
-
-# adding supported hardened build args
-global_build_args += activated_hardening_cflags
 
 # Deprecated kconfig entry handling, to be removed on next major release
 if kconfig_data.has('CONFIG_TASK_MAGIC_VALUE')


### PR DESCRIPTION
Make hardening flags and global sentry security selectable by kconfig.
Previously declared hardening flag inclusion are not (de)activable if needed, for example in debug or when target system flash is too small for such a size impact.