### PR TITLE
autotest: fixing improper IRQn value assertion

### DIFF
--- a/autotest/include/drivers/timer.h
+++ b/autotest/include/drivers/timer.h
@@ -18,6 +18,8 @@ int timer_interrupt_acknowledge(void);
 
 int timer_restart(void);
 
+uint8_t timer_get_irqn(void);
+
 Status timer_map(devh_t *handle);
 
 Status timer_unmap(devh_t handle);

--- a/autotest/src/drivers/timer/stm32-basic-timer.c
+++ b/autotest/src/drivers/timer/stm32-basic-timer.c
@@ -81,6 +81,13 @@ int timer_enable_interrupt(void)
     return 0;
 }
 
+uint8_t timer_get_irqn(void)
+{
+    stm32_timer_desc_t const *desc = stm32_timer_get_desc();
+
+    return desc->irqn;
+}
+
 int timer_set_periodic(void)
 {
     int res = 0;

--- a/autotest/src/tests/test_irq.c
+++ b/autotest/src/tests/test_irq.c
@@ -18,6 +18,7 @@ static void test_irq_spawn_two_it(void)
     Status res;
     uint8_t tab[128];
     uint32_t *IRQn;
+    uint32_t irq = timer_get_irqn();
     timer_enable_interrupt();
     timer_enable();
     /* waiting 1200ms */
@@ -25,7 +26,7 @@ static void test_irq_spawn_two_it(void)
     copy_to_user(&tab[0], sizeof(exchange_event_t) + 4);
     ASSERT_EQ(res, STATUS_OK);
     IRQn = (uint32_t*)&((exchange_event_t*)tab)->data;
-    ASSERT_EQ(*IRQn, 49);
+    ASSERT_EQ(*IRQn, irq);
     timer_enable_interrupt();
     timer_enable();
     /* waiting 1200ms */
@@ -33,7 +34,7 @@ static void test_irq_spawn_two_it(void)
     copy_to_user(&tab[0], sizeof(exchange_event_t) + 4);
     ASSERT_EQ(res, STATUS_OK);
     IRQn = (uint32_t*)&((exchange_event_t*)tab)->data;
-    ASSERT_EQ(*IRQn, 49);
+    ASSERT_EQ(*IRQn, irq);
     return;
 }
 
@@ -41,6 +42,7 @@ static void test_irq_spawn_one_it(void)
 {
     Status res;
     uint8_t tab[128];
+    uint32_t irq = timer_get_irqn();
     timer_enable_interrupt();
     timer_enable();
     /* waiting 1200ms */
@@ -48,7 +50,7 @@ static void test_irq_spawn_one_it(void)
     copy_to_user(&tab[0], sizeof(exchange_event_t) + 4);
     ASSERT_EQ(res, STATUS_OK);
     uint32_t *IRQn = (uint32_t*)&((exchange_event_t*)tab)->data;
-    ASSERT_EQ(*IRQn, 49);
+    ASSERT_EQ(*IRQn, irq);
     ASSERT_EQ(((exchange_event_t*)tab)->source, handle);
     return;
 }
@@ -59,6 +61,7 @@ static void test_irq_spawn_periodic(void)
     Status res;
     uint8_t tab[128];
     uint8_t count;
+    uint32_t irq = timer_get_irqn();
     timer_enable_interrupt();
     timer_set_periodic();
     timer_enable();
@@ -70,7 +73,7 @@ static void test_irq_spawn_periodic(void)
         copy_to_user(&tab[0], sizeof(exchange_event_t) + 4);
         ASSERT_EQ(res, STATUS_OK);
         uint32_t *IRQn = (uint32_t*)&((exchange_event_t*)tab)->data;
-        ASSERT_EQ(*IRQn, 49);
+        ASSERT_EQ(*IRQn, irq);
         if (count < 4) {
             timer_enable_interrupt();
         }


### PR DESCRIPTION
fixing hardcoded IRQn value in IRQ test suite, replaced by dts-based IRQ number definition