### PR TITLE
mpu: fixing invalid RNR value calculation

### DIFF
--- a/kernel/include/sentry/arch/asm-cortex-m/mpu_pmsa_v7.h
+++ b/kernel/include/sentry/arch/asm-cortex-m/mpu_pmsa_v7.h
@@ -106,6 +106,7 @@
 /** MPU Region Size 4 GBytes */
 #define MPU_REGION_SIZE_4GB ARM_MPU_REGION_SIZE_4GB
 
+#define MPU_FASTLOAD_ALIGNED 0
 /*@
   assigns \nothing;
  */

--- a/kernel/include/sentry/arch/asm-cortex-m/mpu_pmsa_v8.h
+++ b/kernel/include/sentry/arch/asm-cortex-m/mpu_pmsa_v8.h
@@ -123,6 +123,7 @@
   (((AP) << MPU_RBAR_AP_Pos) & MPU_RBAR_AP_Msk) | \
   (((XN) << MPU_RBAR_XN_Pos) & MPU_RBAR_XN_Msk))
 
+#define MPU_FASTLOAD_ALIGNED 1
 
 /*@
   assigns (*(MPU_Type*)MPU_BASE);

--- a/kernel/src/managers/memory/memory_mpu.c
+++ b/kernel/src/managers/memory/memory_mpu.c
@@ -221,7 +221,13 @@ kstatus_t mgr_mm_map_device(taskh_t tsk, devh_t dev)
         status = K_ERROR_BUSY;
         goto err;
     }
-    mpu_cfg.id += 2; /* as layout starts at task TXT, defined as reg2, it must be incremented */
+#if ! MPU_FASTLOAD_ALIGNED
+    /* in MPU that allow block-mapping from any region number, the region number is based
+     * on the id field, while in the other case, it is set separatedly */
+    /** FIXME: this fix should be fully invisible here and being instead managed in mpu
+     * arch-specific backend, such as pmsav7 vs pmsav8 */
+    mpu_cfg.id += 2; /* as layout starts at task TXT, defined as reg 2, it must be incremented */
+#endif
     mpu_cfg.addr = (uint32_t)devinfo->baseaddr;
     mpu_cfg.size = mpu_convert_size_to_region(devinfo->size);
     mpu_cfg.access_perm = MPU_REGION_PERM_FULL; /* RW for priv+user */
@@ -290,10 +296,24 @@ kstatus_t mgr_mm_map_shm(taskh_t tsk, shmh_t shm)
     if (unlikely((status = mgr_task_get_layout_from_handle(tsk, &layout_tab)) != K_STATUS_OKAY)) {
         goto err;
     }
+    /**
+     * NOTE: here, we ask for the first empty field in task layout.
+     * This field id must be incremented of 2 (<<1) as the first region of th layout_tab
+     * correspond to region 2 (see kernel and task memory mapping) as the kernel has locked
+     * regions 0 and 1 for itself.
+     */
     if (unlikely((status = mpu_get_free_id(layout_tab, TASK_MAX_RESSOURCES_NUM, &mpu_cfg.id)) != K_STATUS_OKAY)) {
         status = K_ERROR_BUSY;
         goto err;
     }
+
+#if ! MPU_FASTLOAD_ALIGNED
+    /* in MPU that allow block-mapping from any region number, the region number is based
+     * on the id field, while in the other case, it is set separatedly */
+    /** FIXME: this fix should be fully invisible here and being instead managed in mpu
+     * arch-specific backend, such as pmsav7 vs pmsav8 */
+    mpu_cfg.id += 2; /* as layout starts at task TXT, defined as reg2, it must be incremented */
+#endif
     mpu_cfg.addr = (uint32_t)shm_meta->baseaddr;
     mpu_cfg.size = mpu_convert_size_to_region(shm_meta->size);
 


### PR DESCRIPTION
This bug is not triggered in pmsav8 but is in pmsav7.

The in-RBAR register RNR value is used in pmsav7 fastload mechanism in order to specify the region that need to be updated. In pmsav8, this is not used as RNR register is used alongside multi-word writting by the CMSIS ARM implementation.
As a consequence, this bug had no impact on pmsav8 (armv8-m) but is striggered as soon as a task maps something in pmsav7 (the first resource mapped, whatever is it, being mapped at RNR 5, requiring a double ordered memcpy to the MPU.
This bug was not triggered in v7 while only mapping 4 first regions.

The fix is not the best one, and #95 has been opened for a better integrated fix.