### PR TITLE
uapi: add support for complete systypes and cargo ecosystem

### DIFF
--- a/uapi/meson.build
+++ b/uapi/meson.build
@@ -98,7 +98,6 @@ test(
         '--test-threads=1',
     ],
     is_parallel: false,
-    should_fail: true,
     suite: 'uapi',
 )
 

--- a/uapi/src/arch/x86_64.rs
+++ b/uapi/src/arch/x86_64.rs
@@ -5,11 +5,7 @@
 
 use crate::systypes::*;
 
-#[cfg(test)]
-use sysgate::gate;
-
 pub fn debug_syscall_handler(syscall_number: u8, args: &[u32]) -> u32 {
-    #[cfg(not(test))]
     match Syscall::try_from(syscall_number) {
         Ok(sysc) => {
             #[cfg(feature = "std")]
@@ -21,12 +17,6 @@ pub fn debug_syscall_handler(syscall_number: u8, args: &[u32]) -> u32 {
             eprintln!("! {syscall_number} is not a syscall number");
             Status::Invalid as u32
         }
-    }
-
-    #[cfg(test)]
-    match gate::syscall_dispatch(syscall_number, args) {
-        Ok(_) => Status::Ok as u32,
-        Err(x) => x as u32,
     }
 }
 

--- a/uapi/src/ffi_c.rs
+++ b/uapi/src/ffi_c.rs
@@ -4,7 +4,7 @@
 use crate::systypes::*;
 
 #[no_mangle]
-pub extern "C" fn __sys_get_process_handle(process: ProcessLabel) -> Status {
+pub extern "C" fn __sys_get_process_handle(process: TaskLabel) -> Status {
     crate::syscall::get_process_handle(process)
 }
 
@@ -34,37 +34,41 @@ pub extern "C" fn __sys_sleep(duration_ms: SleepDuration, mode: SleepMode) -> St
 }
 
 #[no_mangle]
-pub extern "C" fn __sys_start(process: ProcessLabel) -> Status {
+pub extern "C" fn __sys_start(process: TaskLabel) -> Status {
     crate::syscall::start(process)
 }
 
 #[no_mangle]
-pub extern "C" fn __sys_map_dev(dev: devh_t) -> Status {
-    crate::syscall::map_dev(dev as devh_t)
+pub extern "C" fn __sys_map_dev(dev: DeviceHandle) -> Status {
+    crate::syscall::map_dev(dev as DeviceHandle)
 }
 
 #[no_mangle]
-pub extern "C" fn __sys_map_shm(shm: shmh_t) -> Status {
-    crate::syscall::map_shm(shm as shmh_t)
+pub extern "C" fn __sys_map_shm(shm: ShmHandle) -> Status {
+    crate::syscall::map_shm(shm as ShmHandle)
 }
 
 #[no_mangle]
-pub extern "C" fn __sys_unmap_dev(dev: devh_t) -> Status {
-    crate::syscall::unmap_dev(dev as devh_t)
+pub extern "C" fn __sys_unmap_dev(dev: DeviceHandle) -> Status {
+    crate::syscall::unmap_dev(dev as DeviceHandle)
 }
 
 #[no_mangle]
-pub extern "C" fn __sys_unmap_shm(shm: shmh_t) -> Status {
-    crate::syscall::unmap_shm(shm as shmh_t)
+pub extern "C" fn __sys_unmap_shm(shm: ShmHandle) -> Status {
+    crate::syscall::unmap_shm(shm as ShmHandle)
 }
 
 #[no_mangle]
-pub extern "C" fn __sys_shm_set_credential(shm: shmh_t, id: taskh_t, shm_perm: u32) -> Status {
+pub extern "C" fn __sys_shm_set_credential(
+    shm: ShmHandle,
+    id: TaskHandle,
+    shm_perm: u32,
+) -> Status {
     crate::syscall::shm_set_credential(shm, id, shm_perm)
 }
 
 #[no_mangle]
-pub extern "C" fn __sys_send_ipc(target: taskh_t, length: u8) -> Status {
+pub extern "C" fn __sys_send_ipc(target: TaskHandle, length: u8) -> Status {
     crate::syscall::send_ipc(target, length)
 }
 
@@ -154,41 +158,41 @@ pub extern "C" fn __sys_pm_set_clock(clk_reg: u32, clkmsk: u32, val: u32) -> Sta
 }
 
 #[no_mangle]
-pub extern "C" fn __sys_dma_start_stream(dmah: dmah_t) -> Status {
+pub extern "C" fn __sys_dma_start_stream(dmah: StreamHandle) -> Status {
     crate::syscall::dma_start_stream(dmah)
 }
 
 #[no_mangle]
-pub extern "C" fn __sys_dma_suspend_stream(dmah: dmah_t) -> Status {
+pub extern "C" fn __sys_dma_suspend_stream(dmah: StreamHandle) -> Status {
     crate::syscall::dma_suspend_stream(dmah)
 }
 
 #[no_mangle]
-pub extern "C" fn __sys_dma_get_stream_status(dmah: dmah_t) -> Status {
+pub extern "C" fn __sys_dma_get_stream_status(dmah: StreamHandle) -> Status {
     crate::syscall::dma_get_stream_status(dmah)
 }
 
 #[no_mangle]
-pub extern "C" fn __sys_shm_get_infos(shm: shmh_t) -> Status {
+pub extern "C" fn __sys_shm_get_infos(shm: ShmHandle) -> Status {
     crate::syscall::shm_get_infos(shm)
 }
 
 #[no_mangle]
-pub extern "C" fn __sys_dma_assign_stream(dmah: dmah_t) -> Status {
+pub extern "C" fn __sys_dma_assign_stream(dmah: StreamHandle) -> Status {
     crate::syscall::dma_assign_stream(dmah)
 }
 
 #[no_mangle]
-pub extern "C" fn __sys_dma_unassign_stream(dmah: dmah_t) -> Status {
+pub extern "C" fn __sys_dma_unassign_stream(dmah: StreamHandle) -> Status {
     crate::syscall::dma_unassign_stream(dmah)
 }
 
 #[no_mangle]
-pub extern "C" fn __sys_dma_get_stream_info(dmah: dmah_t) -> Status {
+pub extern "C" fn __sys_dma_get_stream_info(dmah: StreamHandle) -> Status {
     crate::syscall::dma_get_stream_info(dmah)
 }
 
 #[no_mangle]
-pub extern "C" fn __sys_dma_resume_stream(dmah: dmah_t) -> Status {
+pub extern "C" fn __sys_dma_resume_stream(dmah: StreamHandle) -> Status {
     crate::syscall::dma_resume_stream(dmah)
 }

--- a/uapi/src/lib.rs
+++ b/uapi/src/lib.rs
@@ -17,8 +17,7 @@
 //!
 //! -**Sentry syscalls** — Syscall are defined in a two layers way. The bare syscalls
 //!  are implemented in the [`mod@syscall`] module, while the upper, easy interface
-//!  is implemented in the [`mod@uapi`] module. Unless specific needs, there is no
-//!  usual case where the [`mod@syscall`] module interface needs to be acceded directly.
+//!  is out of the scope of this very crate, and written in the shield crate instead.
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
@@ -34,7 +33,7 @@ mod arch;
 /// This allows a full Rust usage without extern C and thus unsafe calls when
 /// writing Rust application with cargo
 /// interface is used. Sentry kernel interactions should be, instead, made with
-/// the [`mod@uapi`] upper interface.
+/// a upper interface such as shield.
 ///
 pub mod ffi_c;
 
@@ -44,7 +43,7 @@ pub mod ffi_c;
 ///
 /// This module should not be used directly unless the [`mod@syscall`] module
 /// interface is used. Sentry kernel interactions should be, instead, made with
-/// the [`mod@uapi`] upper interface.
+/// an upper interface.
 ///
 /// As the SVC_EXCHANGE area is a special userspace/kernelspace fixed size area
 /// made in order to exchange data between userspace and kernelspace without
@@ -73,8 +72,8 @@ pub mod svc_exchange;
 /// architecture supervisor access opcode, in interaction with the corresponding
 /// arch backend.
 ///
-/// There is no abstraction at this module's level and should not be used directly.
-/// The [`mod@uapi`] module should be used instead.
+/// There is no abstraction at this module's level and should not be used directly,
+/// but instead with an upper interface such as shield
 ///
 /// > **NOTE**: This module may not be kept public forever
 ///

--- a/uapi/src/syscall.rs
+++ b/uapi/src/syscall.rs
@@ -24,8 +24,8 @@ use core::arch::asm;
 ///
 /// # Example
 ///
-/// ```rust
-/// syscall::exit(42);
+/// ```ignore
+/// sentry_uapi::syscall::exit(42);
 /// // unreachable
 /// ```
 ///
@@ -50,9 +50,9 @@ pub fn exit(status: i32) -> Status {
 ///
 /// # Example
 ///
-/// ```rust
-/// match get_process_handle(tasklabel) {
-///    Status::Ok => (),
+/// ```ignore
+/// match sentry_uapi::syscall::get_process_handle(tasklabel) {
+///     Status::Ok => (),
 ///     any_err => return (any_err),
 /// }
 /// let exch_area = unsafe { &mut SVC_EXCHANGE_AREA[..4] };
@@ -79,9 +79,9 @@ pub fn get_process_handle(process: ProcessLabel) -> Status {
 ///
 /// # Example
 ///
-/// ```rust
-/// match get_shm_handle(shmlabel) {
-///    Status::Ok => (),
+/// ```ignore
+/// match sentry_uapi::syscall::get_shm_handle(shmlabel) {
+///     Status::Ok => (),
 ///     any_err => return (any_err),
 /// }
 /// let exch_area = unsafe { &mut SVC_EXCHANGE_AREA[..4] };
@@ -108,7 +108,7 @@ pub fn get_shm_handle(shm: ShmLabel) -> Status {
 ///
 /// # Example
 ///
-/// ```rust
+/// ```ignore
 /// match get_dma_stream_handle(streamlabel) {
 ///    Status::Ok => (),
 ///     any_err => return (any_err),
@@ -142,8 +142,8 @@ pub fn get_dma_stream_handle(stream: StreamLabel) -> Status {
 ///
 /// # Example
 ///
-/// ```rust
-/// syscall::sched_yield();
+/// ```ignore
+/// sentry_uapi::syscall::sched_yield();
 /// ```
 ///
 #[inline(always)]
@@ -178,8 +178,8 @@ pub fn sched_yield() -> Status {
 ///
 /// # Example
 ///
-/// ```rust
-/// match sleep(SleepMode::Deep, D5ms) {
+/// ```ignore
+/// match sentry_uapi::syscall::sleep(SleepMode::Deep, D5ms) {
 ///    Status::Intr => (),
 ///    Status::Timeout => (),
 /// }
@@ -206,7 +206,7 @@ pub fn sleep(duration_ms: SleepDuration, mode: SleepMode) -> Status {
 ///
 /// # Example
 ///
-/// ```rust
+/// ```ignore
 /// match start(tsklabel) {
 ///    Status::Ok => (),
 ///    any_err => return(any_err),
@@ -242,7 +242,7 @@ pub fn start(process: ProcessLabel) -> Status {
 ///
 /// # Example
 ///
-/// ```rust
+/// ```ignore
 /// match map_dev(devh) {
 ///    Status::Ok => (),
 ///    Status::Busy => (unmap_other()),
@@ -280,7 +280,7 @@ pub fn map_dev(dev: devh_t) -> Status {
 ///
 /// # Example
 ///
-/// ```rust
+/// ```ignore
 /// match map_shm(shmh) {
 ///    Status::Ok => (),
 ///    Status::Busy => (unmap_other()),
@@ -313,7 +313,7 @@ pub fn map_shm(shm: shmh_t) -> Status {
 ///
 /// # Example
 ///
-/// ```rust
+/// ```ignore
 /// match unmap_dev(devh) {
 ///    Status::Ok => (),
 ///    any_err => return(any_err),
@@ -344,7 +344,7 @@ pub fn unmap_dev(dev: devh_t) -> Status {
 ///
 /// # Example
 ///
-/// ```rust
+/// ```ignore
 /// match unmap_shm(devh) {
 ///    Status::Ok => (),
 ///    any_err => return(any_err),
@@ -398,7 +398,7 @@ pub fn unmap_shm(shm: shmh_t) -> Status {
 ///
 /// # Example
 ///
-/// ```rust
+/// ```ignore
 /// match shm_set_credential(shmh, myhandle, SHMPermission::Map | SHMPermission::Write) {
 ///    Status::Ok => (),
 ///    any_err => return(any_err),
@@ -448,7 +448,7 @@ pub fn shm_set_credential(shm: shmh_t, id: taskh_t, shm_perm: u32) -> Status {
 ///
 /// # examples
 ///
-/// ```
+/// ```ignore
 /// uapi::send_ipc(TargetTaskh, IpcLen)?continue_here;
 /// ```
 ///
@@ -488,7 +488,7 @@ pub fn send_ipc(target: taskh_t, length: u8) -> Status {
 ///
 /// # examples
 ///
-/// ```
+/// ```ignore
 /// send_signal(TargetTaskh, Signal::Pipe)?continue_here;
 /// ```
 ///
@@ -535,7 +535,7 @@ pub fn send_signal(resource: u32, signal_type: Signal) -> Status {
 ///
 /// # Example
 ///
-/// ```rust
+/// ```ignore
 /// gpio_get(devh, Sda);
 /// ```
 ///
@@ -623,12 +623,17 @@ pub fn gpio_configure(resource: u32, io: u8) -> Status {
 /// # Example
 ///
 /// ```rust
-/// match get_device_handle(devlabel) {
-///    Status::Ok => (),
-///     any_err => return (any_err),
+/// use sentry_uapi::{syscall, svc_exchange::*, systypes::*};
+///
+/// fn get_handle() -> Result<u32, sentry_uapi::systypes::Status> {
+///     let devlabel : u8 = 0x42;
+///     match syscall::get_device_handle(devlabel) {
+///         Status::Ok => (),
+///         any_err => return Err(any_err),
+///     };
+///     let exch_area = unsafe { &mut SVC_EXCHANGE_AREA[..4] };
+///     Ok(u32::from_ne_bytes(exch_area.try_into().map_err(|_| Status::Invalid)?))
 /// }
-/// let exch_area = unsafe { &mut SVC_EXCHANGE_AREA[..4] };
-/// let handle = u32::from_ne_bytes(exch_area.try_into().map_err(|_| Status::Invalid)?);
 /// ```
 ///
 #[inline(always)]
@@ -735,7 +740,7 @@ pub fn log(length: usize) -> Status {
 ///
 /// # Example
 ///
-/// ```rust
+/// ```ignore
 /// match (get_random()) {
 ///     Status::Ok => (),
 ///     any_err => return(any_err),
@@ -871,10 +876,7 @@ mod tests {
 
     #[test]
     fn basic_sleep() {
-        assert_eq!(
-            sleep(SleepDuration::D1ms, SleepMode::Shallow),
-            Status::Ok
-        );
+        assert_eq!(sleep(SleepDuration::D1ms, SleepMode::Shallow), Status::Ok);
     }
 
     #[test]
@@ -893,7 +895,6 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
     fn invalid_status() {
         assert_eq!(exit(0xaaaa), Status::Ok);
     }

--- a/uapi/src/syscall.rs
+++ b/uapi/src/syscall.rs
@@ -60,7 +60,7 @@ pub fn exit(status: i32) -> Status {
 /// ```
 ///
 #[inline(always)]
-pub fn get_process_handle(process: ProcessLabel) -> Status {
+pub fn get_process_handle(process: TaskLabel) -> Status {
     syscall!(Syscall::GetProcessHandle, process).into()
 }
 
@@ -214,7 +214,7 @@ pub fn sleep(duration_ms: SleepDuration, mode: SleepMode) -> Status {
 /// ```
 ///
 #[inline(always)]
-pub fn start(process: ProcessLabel) -> Status {
+pub fn start(process: TaskLabel) -> Status {
     syscall!(Syscall::Start, process).into()
 }
 
@@ -251,7 +251,7 @@ pub fn start(process: ProcessLabel) -> Status {
 /// ```
 ///
 #[inline(always)]
-pub fn map_dev(dev: devh_t) -> Status {
+pub fn map_dev(dev: DeviceHandle) -> Status {
     syscall!(Syscall::MapDev, dev).into()
 }
 
@@ -289,7 +289,7 @@ pub fn map_dev(dev: devh_t) -> Status {
 /// ```
 ///
 #[inline(always)]
-pub fn map_shm(shm: shmh_t) -> Status {
+pub fn map_shm(shm: ShmHandle) -> Status {
     syscall!(Syscall::MapShm, shm).into()
 }
 
@@ -321,7 +321,7 @@ pub fn map_shm(shm: shmh_t) -> Status {
 /// ```
 ///
 #[inline(always)]
-pub fn unmap_dev(dev: devh_t) -> Status {
+pub fn unmap_dev(dev: DeviceHandle) -> Status {
     syscall!(Syscall::UnmapDev, dev).into()
 }
 
@@ -352,7 +352,7 @@ pub fn unmap_dev(dev: devh_t) -> Status {
 /// ```
 ///
 #[inline(always)]
-pub fn unmap_shm(shm: shmh_t) -> Status {
+pub fn unmap_shm(shm: ShmHandle) -> Status {
     syscall!(Syscall::UnmapShm, shm).into()
 }
 
@@ -411,7 +411,7 @@ pub fn unmap_shm(shm: shmh_t) -> Status {
 /// [`get_shm_handle`], [`map_shm`], [`unmap_shm`] and [`shm_get_infos`].
 ///
 #[inline(always)]
-pub fn shm_set_credential(shm: shmh_t, id: taskh_t, shm_perm: u32) -> Status {
+pub fn shm_set_credential(shm: ShmHandle, id: TaskHandle, shm_perm: u32) -> Status {
     syscall!(Syscall::SHMSetCredential, shm, id, shm_perm).into()
 }
 
@@ -453,7 +453,7 @@ pub fn shm_set_credential(shm: shmh_t, id: taskh_t, shm_perm: u32) -> Status {
 /// ```
 ///
 #[inline(always)]
-pub fn send_ipc(target: taskh_t, length: u8) -> Status {
+pub fn send_ipc(target: TaskHandle, length: u8) -> Status {
     syscall!(Syscall::SendIPC, target, length as u32).into()
 }
 
@@ -797,7 +797,7 @@ pub fn pm_set_clock(clk_reg: u32, clkmsk: u32, val: u32) -> Status {
 ///
 /// TODO: with complete DMA support
 #[inline(always)]
-pub fn dma_start_stream(dmah: dmah_t) -> Status {
+pub fn dma_start_stream(dmah: StreamHandle) -> Status {
     syscall!(Syscall::DmaStartStream, dmah).into()
 }
 
@@ -805,7 +805,7 @@ pub fn dma_start_stream(dmah: dmah_t) -> Status {
 ///
 /// TODO: with complete DMA support
 #[inline(always)]
-pub fn dma_suspend_stream(dmah: dmah_t) -> Status {
+pub fn dma_suspend_stream(dmah: StreamHandle) -> Status {
     syscall!(Syscall::DmaSuspendStream, dmah).into()
 }
 
@@ -813,7 +813,7 @@ pub fn dma_suspend_stream(dmah: dmah_t) -> Status {
 ///
 /// TODO: with complete DMA support
 #[inline(always)]
-pub fn dma_get_stream_status(dmah: dmah_t) -> Status {
+pub fn dma_get_stream_status(dmah: StreamHandle) -> Status {
     syscall!(Syscall::DmaGetStreamStatus, dmah).into()
 }
 
@@ -821,7 +821,7 @@ pub fn dma_get_stream_status(dmah: dmah_t) -> Status {
 ///
 /// TODO: with complete DMA support
 #[inline(always)]
-pub fn shm_get_infos(shm: shmh_t) -> Status {
+pub fn shm_get_infos(shm: ShmHandle) -> Status {
     syscall!(Syscall::ShmGetInfos, shm).into()
 }
 
@@ -829,7 +829,7 @@ pub fn shm_get_infos(shm: shmh_t) -> Status {
 ///
 /// TODO: with complete DMA support
 #[inline(always)]
-pub fn dma_assign_stream(dmah: dmah_t) -> Status {
+pub fn dma_assign_stream(dmah: StreamHandle) -> Status {
     syscall!(Syscall::DmaAssignStream, dmah).into()
 }
 
@@ -837,7 +837,7 @@ pub fn dma_assign_stream(dmah: dmah_t) -> Status {
 ///
 /// TODO: with complete DMA support
 #[inline(always)]
-pub fn dma_unassign_stream(dmah: dmah_t) -> Status {
+pub fn dma_unassign_stream(dmah: StreamHandle) -> Status {
     syscall!(Syscall::DmaUnassignStream, dmah).into()
 }
 
@@ -846,7 +846,7 @@ pub fn dma_unassign_stream(dmah: dmah_t) -> Status {
 ///
 /// TODO: with complete DMA support
 #[inline(always)]
-pub fn dma_get_stream_info(dmah: dmah_t) -> Status {
+pub fn dma_get_stream_info(dmah: StreamHandle) -> Status {
     syscall!(Syscall::DmaGetStreamInfo, dmah).into()
 }
 
@@ -854,7 +854,7 @@ pub fn dma_get_stream_info(dmah: dmah_t) -> Status {
 ///
 /// TODO: with complete DMA support
 #[inline(always)]
-pub fn dma_resume_stream(dmah: dmah_t) -> Status {
+pub fn dma_resume_stream(dmah: StreamHandle) -> Status {
     syscall!(Syscall::DmaResumeStream, dmah).into()
 }
 


### PR DESCRIPTION
- [x] fix cargo fmt through meson test cargo-fmt
- [x] fix cargo test through meson test cargo-test
- [x] add all missing types in systypes.rs so that Rust app do work properly
- [x] Use CamlCase convesion for Rust types, keeping them separated from the C header's snake case convention

Note: all system types are using `repr(C)`, as the kernel is written in C.