### PR TITLE
uapi,ffi_c: fix copy_from/to API to more rust-homogeneous one

### DIFF
--- a/autotest/src/drivers/timer/stm32-basic-timer.c
+++ b/autotest/src/drivers/timer/stm32-basic-timer.c
@@ -137,7 +137,7 @@ Status timer_map(devh_t *handle)
     if (res != STATUS_OK) {
         goto end;
     }
-    copy_to_user((uint8_t*)handle, sizeof(devh_t));
+    copy_from_kernel((uint8_t*)handle, sizeof(devh_t));
     res = __sys_map_dev(*handle);
     if (res != STATUS_OK) {
         goto end;

--- a/autotest/src/printf.c
+++ b/autotest/src/printf.c
@@ -20,7 +20,7 @@ void dbgbuffer_flush(void);
 static inline void dbgbuffer_display(void)
 {
     uint16_t len = log_get_dbgbuf_offset();
-    copy_from_user(log_get_dbgbuf(), len);
+    copy_to_kernel(log_get_dbgbuf(), len);
     __sys_log(len);
 }
 

--- a/autotest/src/tests/test_cycles.c
+++ b/autotest/src/tests/test_cycles.c
@@ -20,25 +20,25 @@ void test_cycles_duration(void)
     /* rearm quantum first */
     __sys_sched_yield();
     __sys_get_cycle(PRECISION_MICROSECONDS);
-    copy_to_user((uint8_t*)&start, sizeof(uint64_t));
+    copy_from_kernel((uint8_t*)&start, sizeof(uint64_t));
     for (idx = 0; idx <= 1000; ++idx) {
         __sys_get_cycle(PRECISION_MICROSECONDS);
     }
     __sys_get_cycle(PRECISION_MICROSECONDS);
-    copy_to_user((uint8_t*)&stop, sizeof(uint64_t));
+    copy_from_kernel((uint8_t*)&stop, sizeof(uint64_t));
 
     LOG("average get_cycle cost: %lu", (uint32_t)((stop - start) / idx));
 
     /* rearm quantum first */
     __sys_sched_yield();
     __sys_get_cycle(PRECISION_MICROSECONDS);
-    copy_to_user((uint8_t*)&start, sizeof(uint64_t));
+    copy_from_kernel((uint8_t*)&start, sizeof(uint64_t));
     for (idx = 0; idx <= 1000; ++idx) {
         __sys_get_cycle(PRECISION_MICROSECONDS);
-        copy_to_user((uint8_t*)&micro, sizeof(uint64_t));
+        copy_from_kernel((uint8_t*)&micro, sizeof(uint64_t));
     }
     __sys_get_cycle(PRECISION_MICROSECONDS);
-    copy_to_user((uint8_t*)&stop, sizeof(uint64_t));
+    copy_from_kernel((uint8_t*)&stop, sizeof(uint64_t));
 
     LOG("average get_cycle+copy cost: %lu", (uint32_t)((stop - start) / idx));
 
@@ -57,15 +57,15 @@ void test_cycles_precision(void)
      * get all the values, and then assert them
      */
     milli_st = __sys_get_cycle(PRECISION_MILLISECONDS);
-    copy_to_user((uint8_t*)&milli, sizeof(uint64_t));
+    copy_from_kernel((uint8_t*)&milli, sizeof(uint64_t));
 
 
     micro_st = __sys_get_cycle(PRECISION_MICROSECONDS);
-    copy_to_user((uint8_t*)&micro, sizeof(uint64_t));
+    copy_from_kernel((uint8_t*)&micro, sizeof(uint64_t));
 
 
     nano_st = __sys_get_cycle(PRECISION_NANOSECONDS);
-    copy_to_user((uint8_t*)&nano, sizeof(uint64_t));
+    copy_from_kernel((uint8_t*)&nano, sizeof(uint64_t));
 
     cycle_st = __sys_get_cycle(PRECISION_CYCLE);
 

--- a/autotest/src/tests/test_dma.c
+++ b/autotest/src/tests/test_dma.c
@@ -18,11 +18,11 @@ static void test_dma_get_handle(dmah_t* d2mstreamh, dmah_t *m2mstreamh)
     Status res;
     TEST_START();
     res = __sys_get_dma_stream_handle(0x1);
-    copy_to_user((uint8_t*)d2mstreamh, sizeof(dmah_t));
+    copy_from_kernel((uint8_t*)d2mstreamh, sizeof(dmah_t));
     ASSERT_EQ(res, STATUS_OK);
     LOG("handle is %lx", *d2mstreamh);
     res = __sys_get_dma_stream_handle(0x2);
-    copy_to_user((uint8_t*)m2mstreamh, sizeof(dmah_t));
+    copy_from_kernel((uint8_t*)m2mstreamh, sizeof(dmah_t));
     ASSERT_EQ(res, STATUS_OK);
     LOG("handle is %lx", *m2mstreamh);
     TEST_END();
@@ -117,29 +117,29 @@ static void test_dma_start_n_wait_stream(dmah_t stream)
     int ret_builtin;
     TEST_START();
     res = __sys_get_process_handle(0xbabeUL);
-    copy_to_user((uint8_t*)&myself, sizeof(taskh_t));
+    copy_from_kernel((uint8_t*)&myself, sizeof(taskh_t));
     // preparing shm1 with content
     res = __sys_get_shm_handle(shms[0].id);
-    copy_to_user((uint8_t*)&shm1, sizeof(shmh_t));
+    copy_from_kernel((uint8_t*)&shm1, sizeof(shmh_t));
     ASSERT_EQ(res, STATUS_OK);
     res = __sys_shm_set_credential(shm1, myself, perms);
     ASSERT_EQ(res, STATUS_OK);
     res = __sys_map_shm(shm1);
     ASSERT_EQ(res, STATUS_OK);
     res = __sys_shm_get_infos(shm1);
-    copy_to_user((uint8_t*)&shminfos1, sizeof(shm_infos_t));
+    copy_from_kernel((uint8_t*)&shminfos1, sizeof(shm_infos_t));
     ASSERT_EQ(res, STATUS_OK);
     memset((void*)shminfos1.base, 0xa5, 0x100UL);
     // garbaging shm2
     res = __sys_get_shm_handle(shms[1].id);
-    copy_to_user((uint8_t*)&shm2, sizeof(shmh_t));
+    copy_from_kernel((uint8_t*)&shm2, sizeof(shmh_t));
     ASSERT_EQ(res, STATUS_OK);
     res = __sys_shm_set_credential(shm2, myself, perms);
     ASSERT_EQ(res, STATUS_OK);
     res = __sys_map_shm(shm2);
     ASSERT_EQ(res, STATUS_OK);
     res = __sys_shm_get_infos(shm2);
-    copy_to_user((uint8_t*)&shminfos2, sizeof(shm_infos_t));
+    copy_from_kernel((uint8_t*)&shminfos2, sizeof(shm_infos_t));
     ASSERT_EQ(res, STATUS_OK);
     memset((void*)shminfos2.base, 0x42, 0x100UL);
     // start stream
@@ -168,15 +168,15 @@ static void test_dma_get_info(dmah_t stream)
     shm_infos_t infos;
     TEST_START();
     res = __sys_get_shm_handle(shms[0].id);
-    copy_to_user((uint8_t*)&shm, sizeof(shmh_t));
+    copy_from_kernel((uint8_t*)&shm, sizeof(shmh_t));
     ASSERT_EQ(res, STATUS_OK);
     res = __sys_shm_get_infos(shm);
-    copy_to_user((uint8_t*)&infos, sizeof(shm_infos_t));
+    copy_from_kernel((uint8_t*)&infos, sizeof(shm_infos_t));
     ASSERT_EQ(res, STATUS_OK);
     res = __sys_get_dma_stream_handle(0x1);
     ASSERT_EQ(res, STATUS_OK);
     res = __sys_dma_get_stream_info(stream);
-    copy_to_user((uint8_t*)&stream_info, sizeof(gpdma_stream_cfg_t));
+    copy_from_kernel((uint8_t*)&stream_info, sizeof(gpdma_stream_cfg_t));
     ASSERT_EQ(res, STATUS_OK);
     ASSERT_EQ((uint32_t)stream_info.stream, 112);
     ASSERT_EQ((uint32_t)stream_info.channel, 1);

--- a/autotest/src/tests/test_gpio.c
+++ b/autotest/src/tests/test_gpio.c
@@ -16,7 +16,7 @@ void test_gpio_on(void)
     devh_t dev;
     TEST_START();
     res = __sys_get_device_handle((uint8_t)devices[DEV_ID_LED0].id);
-    copy_to_user((uint8_t*)&dev, sizeof(devh_t));
+    copy_from_kernel((uint8_t*)&dev, sizeof(devh_t));
     ASSERT_EQ(res, STATUS_OK);
     LOG("handle is %lx", dev);
     res = __sys_gpio_configure(dev, 0);
@@ -33,7 +33,7 @@ void test_gpio_off(void)
 
     TEST_START();
     res = __sys_get_device_handle((uint8_t)devices[DEV_ID_LED0].id);
-    copy_to_user((uint8_t*)&dev, sizeof(devh_t));
+    copy_from_kernel((uint8_t*)&dev, sizeof(devh_t));
     ASSERT_EQ(res, STATUS_OK);
     LOG("handle is %lx", dev);
     res = __sys_gpio_configure(dev, 0);
@@ -53,7 +53,7 @@ void test_gpio_toggle(void)
     duration.arbitrary_ms = 250; /* 250 ms*/
     TEST_START();
     res = __sys_get_device_handle((uint8_t)devices[DEV_ID_LED0].id);
-    copy_to_user((uint8_t*)&dev, sizeof(devh_t));
+    copy_from_kernel((uint8_t*)&dev, sizeof(devh_t));
     res = __sys_gpio_configure(dev, 0);
     ASSERT_EQ(res, STATUS_OK);
     for (uint8_t i = 0; i < 10; ++i) {
@@ -71,7 +71,7 @@ void test_gpio_invalid_io(void)
 
     TEST_START();
     res = __sys_get_device_handle((uint8_t)devices[DEV_ID_LED0].id);
-    copy_to_user((uint8_t*)&dev, sizeof(devh_t));
+    copy_from_kernel((uint8_t*)&dev, sizeof(devh_t));
     res = __sys_gpio_configure(dev, 4);
     ASSERT_EQ(res, STATUS_INVALID);
     res = __sys_gpio_configure(dev, 8);

--- a/autotest/src/tests/test_handle.c
+++ b/autotest/src/tests/test_handle.c
@@ -21,11 +21,11 @@ void test_gethandle(void)
 
     TEST_START();
     /* clear svcexchange first */
-    copy_from_user((uint8_t*)&handle, sizeof(handle));
-    copy_to_user((uint8_t*)&handle, sizeof(handle));
+    copy_to_kernel((uint8_t*)&handle, sizeof(handle));
+    copy_from_kernel((uint8_t*)&handle, sizeof(handle));
     ASSERT_EQ(handle, 0);
     ret = __sys_get_process_handle(0xbabeUL);
-    copy_to_user((uint8_t*)&handle, sizeof(taskh_t));
+    copy_from_kernel((uint8_t*)&handle, sizeof(taskh_t));
     ASSERT_EQ(ret, STATUS_OK);
     LOG("received handle: %lx", handle);
     __builtin_memcpy(&khandle, &handle, sizeof(ktaskh_t));

--- a/autotest/src/tests/test_ipc.c
+++ b/autotest/src/tests/test_ipc.c
@@ -14,7 +14,7 @@ void test_ipc_send_toobig(void)
     taskh_t handle = 0;
     uint8_t len = CONFIG_SVC_EXCHANGE_AREA_LEN+1;
     ret = __sys_get_process_handle(0xbabeUL);
-    copy_to_user((uint8_t*)&handle, sizeof(taskh_t));
+    copy_from_kernel((uint8_t*)&handle, sizeof(taskh_t));
     ASSERT_EQ(ret, STATUS_OK);
     TEST_START();
     LOG("sending invalid IPC size %lu", (uint32_t)len);
@@ -47,15 +47,15 @@ void test_ipc_sendrecv(void)
     exchange_event_t *header;
 
     ret = __sys_get_process_handle(0xbabeUL);
-    copy_to_user((uint8_t*)&handle, sizeof(taskh_t));
+    copy_from_kernel((uint8_t*)&handle, sizeof(taskh_t));
     LOG("handle is %lx", handle);
     ASSERT_EQ(ret, STATUS_OK);
     TEST_START();
     LOG("sending IPC to myself");
-    copy_from_user(msg, 20);
+    copy_to_kernel(msg, 20);
     ret = __sys_send_ipc(handle, 20);
     ret = __sys_wait_for_event(EVENT_TYPE_IPC, timeout);
-    copy_to_user(data, 20+sizeof(exchange_event_t));
+    copy_from_kernel(data, 20+sizeof(exchange_event_t));
     header = (exchange_event_t*)&data[0];
     uint32_t source = header->source;
     char *content = (char*)&header->data[0];
@@ -79,11 +79,11 @@ void test_ipc_deadlock(void)
     exchange_event_t *header;
 
     ret = __sys_get_process_handle(0xbabeUL);
-    copy_to_user((uint8_t*)&handle, sizeof(taskh_t));
+    copy_from_kernel((uint8_t*)&handle, sizeof(taskh_t));
     ASSERT_EQ(ret, STATUS_OK);
     TEST_START();
     LOG("sending IPC to myself");
-    copy_from_user(msg, 20);
+    copy_to_kernel(msg, 20);
     ret = __sys_send_ipc(handle, 20);
     ASSERT_EQ(ret, STATUS_OK);
     LOG("sending another IPC, should lead to STATUS_DEADLK");

--- a/autotest/src/tests/test_irq.c
+++ b/autotest/src/tests/test_irq.c
@@ -23,7 +23,7 @@ static void test_irq_spawn_two_it(void)
     timer_enable();
     /* waiting 1200ms */
     res = __sys_wait_for_event(EVENT_TYPE_IRQ, 0);
-    copy_to_user(&tab[0], sizeof(exchange_event_t) + 4);
+    copy_from_kernel(&tab[0], sizeof(exchange_event_t) + 4);
     ASSERT_EQ(res, STATUS_OK);
     IRQn = (uint32_t*)&((exchange_event_t*)tab)->data;
     ASSERT_EQ(*IRQn, irq);
@@ -31,7 +31,7 @@ static void test_irq_spawn_two_it(void)
     timer_enable();
     /* waiting 1200ms */
     res = __sys_wait_for_event(EVENT_TYPE_IRQ, 0);
-    copy_to_user(&tab[0], sizeof(exchange_event_t) + 4);
+    copy_from_kernel(&tab[0], sizeof(exchange_event_t) + 4);
     ASSERT_EQ(res, STATUS_OK);
     IRQn = (uint32_t*)&((exchange_event_t*)tab)->data;
     ASSERT_EQ(*IRQn, irq);
@@ -47,7 +47,7 @@ static void test_irq_spawn_one_it(void)
     timer_enable();
     /* waiting 1200ms */
     res = __sys_wait_for_event(EVENT_TYPE_IRQ, 0);
-    copy_to_user(&tab[0], sizeof(exchange_event_t) + 4);
+    copy_from_kernel(&tab[0], sizeof(exchange_event_t) + 4);
     ASSERT_EQ(res, STATUS_OK);
     uint32_t *IRQn = (uint32_t*)&((exchange_event_t*)tab)->data;
     ASSERT_EQ(*IRQn, irq);
@@ -70,7 +70,7 @@ static void test_irq_spawn_periodic(void)
         /* reeanble interrupt line (nvic unmasked)*/
         LOG("interrupt count %d wait", count);
         res = __sys_wait_for_event(EVENT_TYPE_IRQ, 0);
-        copy_to_user(&tab[0], sizeof(exchange_event_t) + 4);
+        copy_from_kernel(&tab[0], sizeof(exchange_event_t) + 4);
         ASSERT_EQ(res, STATUS_OK);
         uint32_t *IRQn = (uint32_t*)&((exchange_event_t*)tab)->data;
         ASSERT_EQ(*IRQn, irq);

--- a/autotest/src/tests/test_map.c
+++ b/autotest/src/tests/test_map.c
@@ -15,7 +15,7 @@ void test_map_unmap_notmapped(void) {
     devh_t dev;
     TEST_START();
     res = __sys_get_device_handle((uint8_t)devices[DEV_ID_I2C1].id);
-    copy_to_user((uint8_t*)&dev, sizeof(devh_t));
+    copy_from_kernel((uint8_t*)&dev, sizeof(devh_t));
     ASSERT_EQ(res, STATUS_OK);
     res = __sys_unmap_dev(dev);
     ASSERT_EQ(res, STATUS_INVALID);
@@ -27,7 +27,7 @@ void test_map_invalidmap(void) {
     devh_t dev;
     TEST_START();
     res = __sys_get_device_handle((uint8_t)devices[DEV_ID_I2C1].id);
-    copy_to_user((uint8_t*)&dev, sizeof(devh_t));
+    copy_from_kernel((uint8_t*)&dev, sizeof(devh_t));
     ASSERT_EQ(res, STATUS_OK);
     dev += 42;
     res = __sys_map_dev(dev);
@@ -41,7 +41,7 @@ void test_map_mapunmap(void) {
 
     TEST_START();
     res = __sys_get_device_handle((uint8_t)devices[DEV_ID_I2C1].id);
-    copy_to_user((uint8_t*)&dev, sizeof(devh_t));
+    copy_from_kernel((uint8_t*)&dev, sizeof(devh_t));
     ASSERT_EQ(res, STATUS_OK);
     LOG("handle is %lx", dev);
     res = __sys_map_dev(dev);

--- a/autotest/src/tests/test_random.c
+++ b/autotest/src/tests/test_random.c
@@ -17,7 +17,7 @@ void test_random_sequence(void)
     LOG("get back random value from KRNG");
     for (uint32_t idx = 0; idx < 5; ++idx) {
         ret = __sys_get_random();
-        copy_to_user((uint8_t*)&rng, sizeof(uint32_t));
+        copy_from_kernel((uint8_t*)&rng, sizeof(uint32_t));
         ASSERT_EQ(ret, STATUS_OK);
         LOG("rng retreived: 0x%lx", rng);
     }
@@ -30,13 +30,13 @@ void test_random_duration(void)
     uint32_t rng, idx;
     __sys_sched_yield();
     __sys_get_cycle(PRECISION_MICROSECONDS);
-    copy_to_user((uint8_t*)&start, sizeof(uint64_t));
+    copy_from_kernel((uint8_t*)&start, sizeof(uint64_t));
     for (idx = 0; idx <= 1000; ++idx) {
         __sys_get_random();
-        copy_to_user((uint8_t*)&rng, sizeof(uint32_t));
+        copy_from_kernel((uint8_t*)&rng, sizeof(uint32_t));
     }
     __sys_get_cycle(PRECISION_MICROSECONDS);
-    copy_to_user((uint8_t*)&stop, sizeof(uint64_t));
+    copy_from_kernel((uint8_t*)&stop, sizeof(uint64_t));
     LOG("average get_random+copy cost: %lu", (uint32_t)((stop - start) / idx));
 }
 

--- a/autotest/src/tests/test_shm.c
+++ b/autotest/src/tests/test_shm.c
@@ -46,7 +46,7 @@ void test_shm_unmap_notmapped(void) {
     shmh_t shm;
     TEST_START();
     res = __sys_get_shm_handle(SHM_MAP_DMAPOOL);
-    copy_to_user((uint8_t*)&shm, sizeof(shmh_t));
+    copy_from_kernel((uint8_t*)&shm, sizeof(shmh_t));
     ASSERT_EQ(res, STATUS_OK);
     res = __sys_unmap_shm(shm);
     ASSERT_EQ(res, STATUS_INVALID);
@@ -58,7 +58,7 @@ void test_shm_invalidmap(void) {
     shmh_t shm;
     TEST_START();
     res = __sys_get_shm_handle(SHM_MAP_DMAPOOL);
-    copy_to_user((uint8_t*)&shm, sizeof(shmh_t));
+    copy_from_kernel((uint8_t*)&shm, sizeof(shmh_t));
     ASSERT_EQ(res, STATUS_OK);
     shm += 42;
     res = __sys_map_shm(shm);
@@ -74,7 +74,7 @@ void test_shm_mapdenied(void) {
     perms |= SHM_PERMISSION_MAP;
     TEST_START();
     res = __sys_get_shm_handle(SHM_NOMAP_DMAPOOL);
-    copy_to_user((uint8_t*)&shm, sizeof(shmh_t));
+    copy_from_kernel((uint8_t*)&shm, sizeof(shmh_t));
     ASSERT_EQ(res, STATUS_OK);
     res = __sys_shm_set_credential(shm, myself, perms);
     ASSERT_EQ(res, STATUS_OK);
@@ -89,10 +89,10 @@ void test_shm_infos(void) {
     shm_infos_t infos;
     TEST_START();
     res = __sys_get_shm_handle(shms[0].id);
-    copy_to_user((uint8_t*)&shm, sizeof(shmh_t));
+    copy_from_kernel((uint8_t*)&shm, sizeof(shmh_t));
     ASSERT_EQ(res, STATUS_OK);
     res = __sys_shm_get_infos(shm);
-    copy_to_user((uint8_t*)&infos, sizeof(shm_infos_t));
+    copy_from_kernel((uint8_t*)&infos, sizeof(shm_infos_t));
 
     ASSERT_EQ(res, STATUS_OK);
     ASSERT_EQ(infos.label, shms[0].id);
@@ -109,10 +109,10 @@ void test_shm_creds_on_mapped(void) {
     TEST_START();
     /* get own handle first */
     res = __sys_get_process_handle(0xbabeUL);
-    copy_to_user((uint8_t*)&myself, sizeof(taskh_t));
+    copy_from_kernel((uint8_t*)&myself, sizeof(taskh_t));
     /* get shm handle then */
     res = __sys_get_shm_handle(SHM_MAP_DMAPOOL);
-    copy_to_user((uint8_t*)&shm, sizeof(shmh_t));
+    copy_from_kernel((uint8_t*)&shm, sizeof(shmh_t));
     ASSERT_EQ(res, STATUS_OK);
     uint32_t perms = (SHM_PERMISSION_MAP | SHM_PERMISSION_WRITE);
     res = __sys_shm_set_credential(shm, myself, perms);
@@ -140,10 +140,10 @@ void test_shm_allows_idle(void) {
     TEST_START();
     /* get idle handle first */
     res = __sys_get_process_handle(0xcafeUL);
-    copy_to_user((uint8_t*)&idle, sizeof(taskh_t));
+    copy_from_kernel((uint8_t*)&idle, sizeof(taskh_t));
     /* get shm handle then */
     res = __sys_get_shm_handle(SHM_MAP_DMAPOOL);
-    copy_to_user((uint8_t*)&shm, sizeof(shmh_t));
+    copy_from_kernel((uint8_t*)&shm, sizeof(shmh_t));
     ASSERT_EQ(res, STATUS_OK);
     uint32_t perms = SHM_PERMISSION_TRANSFER;
     res = __sys_shm_set_credential(shm, idle, perms);
@@ -157,10 +157,10 @@ void test_shm_map_unmappable(void) {
     TEST_START();
     /* get own handle first */
     res = __sys_get_process_handle(0xbabeUL);
-    copy_to_user((uint8_t*)&myself, sizeof(taskh_t));
+    copy_from_kernel((uint8_t*)&myself, sizeof(taskh_t));
     /* get shm handle then */
     res = __sys_get_shm_handle(SHM_MAP_DMAPOOL);
-    copy_to_user((uint8_t*)&shm, sizeof(shmh_t));
+    copy_from_kernel((uint8_t*)&shm, sizeof(shmh_t));
     ASSERT_EQ(res, STATUS_OK);
     LOG("handle is %lx", shm);
     /* give full write to myself */
@@ -181,10 +181,10 @@ void test_shm_mapunmap(void) {
     TEST_START();
     /* get own handle first */
     res = __sys_get_process_handle(0xbabeUL);
-    copy_to_user((uint8_t*)&myself, sizeof(taskh_t));
+    copy_from_kernel((uint8_t*)&myself, sizeof(taskh_t));
     /* get shm handle then */
     res = __sys_get_shm_handle(SHM_MAP_DMAPOOL);
-    copy_to_user((uint8_t*)&shm, sizeof(shmh_t));
+    copy_from_kernel((uint8_t*)&shm, sizeof(shmh_t));
     LOG("handle is %lx", shm);
     ASSERT_EQ(res, STATUS_OK);
     /* give full write to myself */

--- a/autotest/src/tests/test_signal.c
+++ b/autotest/src/tests/test_signal.c
@@ -18,7 +18,7 @@ void test_signal_sendrecv(void)
     exchange_event_t *header;
 
     ret = __sys_get_process_handle(0xbabeUL);
-    copy_to_user((uint8_t*)&handle, sizeof(taskh_t));
+    copy_from_kernel((uint8_t*)&handle, sizeof(taskh_t));
     LOG("handle is %lx", handle);
     ASSERT_EQ(ret, STATUS_OK);
     TEST_START();
@@ -27,7 +27,7 @@ void test_signal_sendrecv(void)
         LOG("sending signal %u to myself", sig);
         ret = __sys_send_signal(handle, sig);
         ret = __sys_wait_for_event(EVENT_TYPE_SIGNAL, timeout);
-        copy_to_user(data, 4+sizeof(exchange_event_t));
+        copy_from_kernel(data, 4+sizeof(exchange_event_t));
         header = (exchange_event_t*)&data[0];
         uint32_t* content = (uint32_t*)&header->data[0];
         LOG("%x:%u:%x:src=%lx signal=%lu",

--- a/autotest/src/tests/test_sleep.c
+++ b/autotest/src/tests/test_sleep.c
@@ -47,10 +47,10 @@ void test_sleep_duration(void)
          * get all the values, and then assert them
          */
         cycle_start_st = __sys_get_cycle(PRECISION_MILLISECONDS);
-        copy_to_user((uint8_t*)&start, sizeof(uint64_t));
+        copy_from_kernel((uint8_t*)&start, sizeof(uint64_t));
         sleep_st = __sys_sleep(duration, SLEEP_MODE_DEEP);
         cycle_end_st = __sys_get_cycle(PRECISION_MILLISECONDS);
-        copy_to_user((uint8_t*)&stop, sizeof(uint64_t));
+        copy_from_kernel((uint8_t*)&stop, sizeof(uint64_t));
 
         ASSERT_EQ(cycle_start_st, STATUS_OK);
         ASSERT_EQ(sleep_st, STATUS_TIMEOUT);

--- a/idle/src/main.c
+++ b/idle/src/main.c
@@ -37,10 +37,10 @@ void __attribute__((no_stack_protector, used, noreturn)) idle(uint32_t label, ui
     /* update SSP value with given seed */
     __stack_chk_guard = seed;
 
-    copy_from_user(welcommsg, 20);
+    copy_to_kernel(welcommsg, 20);
     __sys_log(20);
 
-    copy_from_user(yieldmsg, 26);
+    copy_to_kernel(yieldmsg, 26);
     __sys_log(26);
     /* TODO: yield() first, to force task scheduling */
     __sys_sched_yield();

--- a/uapi/include/uapi/uapi.h
+++ b/uapi/include/uapi/uapi.h
@@ -44,7 +44,7 @@ size_t svcexchange_get_maxlen(void);
  * Callers must ensure memory pointed to by `from` up to `from + length` belongs to
  * a valid variable.
  */
-Status copy_from_user(const uint8_t *from, size_t length);
+Status copy_to_kernel(const uint8_t *from, size_t length);
 
 /**
  * Copy data from svc_exchange area to user-controlled buffer
@@ -54,7 +54,7 @@ Status copy_from_user(const uint8_t *from, size_t length);
  * Callers must ensure memory pointed to by `from` up to `from + length` belongs to
  * a valid variable.
  */
-Status copy_to_user(uint8_t *to, size_t length);
+Status copy_from_kernel(uint8_t *to, size_t length);
 
 /**
  * Clear overall svc_exchange area with default 0x0 pattern

--- a/uapi/src/ffi_c.rs
+++ b/uapi/src/ffi_c.rs
@@ -238,7 +238,7 @@ pub extern "C" fn __sys_dma_resume_stream(dmah: StreamHandle) -> Status {
 
 /// C interface to [`crate::copy_to_kernel`] Rust implementation
 #[no_mangle]
-pub extern "C" fn copy_from_user(from: *mut u8, length: usize) -> Status {
+pub extern "C" fn copy_to_kernel(from: *mut u8, length: usize) -> Status {
     let u8_slice: &[u8] = unsafe { core::slice::from_raw_parts(from, length) };
     match exchange::copy_to_kernel(&u8_slice) {
         Ok(_) => Status::Ok,
@@ -248,7 +248,7 @@ pub extern "C" fn copy_from_user(from: *mut u8, length: usize) -> Status {
 
 /// C interface to [`crate::copy_from_kernel`] Rust implementation
 #[no_mangle]
-pub extern "C" fn copy_to_user(to: *mut u8, length: usize) -> Status {
+pub extern "C" fn copy_from_kernel(to: *mut u8, length: usize) -> Status {
     let mut u8_slice: &mut [u8] =
         unsafe { core::slice::from_raw_parts_mut(to, length) as &mut [u8] };
     match exchange::copy_from_kernel(&mut u8_slice) {


### PR DESCRIPTION
Instead of using Linux-like copy_from_user/copy_to_user (which do not have the very same meaning as the current UAPI exchange model), using copy_to_kernel/copy_from_kernel API