### PR TITLE
uapi: do not include --target in rustargs

### DIFF
--- a/uapi/rustargs.in
+++ b/uapi/rustargs.in
@@ -1,3 +1,5 @@
 {% for arg in rustargs.split(' ') -%}
+{% if not arg.startswith('--target') -%}
 {{ arg }}
+{% endif -%}
 {% endfor -%}


### PR DESCRIPTION
otherwise, cargo will append a wrong target specifier to proc-macros...