### PR TITLE
uapi: start support for rustic events (DMA, IPC, Signals and IRQ) manipulation

### DIFF
--- a/uapi/src/exchange.rs
+++ b/uapi/src/exchange.rs
@@ -183,7 +183,9 @@ impl SentryExchangeable for crate::systypes::Event<'_> {
     ///
     #[cfg(not(test))]
     fn to_kernel(&self) -> Result<Status, Status> {
-        if self.header.is_ipc() {
+        use crate::systypes::EventType;
+
+        if self.header.event == EventType::Ipc.into() {
             self.data.to_kernel()
         } else {
             Err(Status::Invalid)

--- a/uapi/src/exchange.rs
+++ b/uapi/src/exchange.rs
@@ -102,10 +102,47 @@ impl ExchangeHeader {
 
 /// Event SentryExchangeable trait implementation
 ///
-/// Events are received from the kernel and hold a header and an associated data bloc.
-/// The SentryExchangeable trait only support, in nominal mode, the from_kernel() usage,
-/// as Events are not emitted but instead use the send_xxx syscalls API
+/// Events are objects that are used to hold event ifnormation that need to be delivered or
+/// received from the kernel.
 ///
+/// Events are received from the kernel and hold a header and an associated data bloc.
+/// The SentryExchangeable trait only support, in nominal mode, the from_kernel() usage for any
+/// event, and to_kernel when emitting IPC
+///
+/// This trait allows to easily receive or deliver properly formatted events, including the
+/// event header forged by the kernel and associated data.
+///
+/// # Example
+///
+/// ```ignore
+/// let mut my_event = uapi::systypes::Event {
+///     header: uapi::systypes::ExchangeHeader {
+///         peer: 0,
+///         event: uapi::systypes::EventType::None.into(),
+///         length: 0,
+///         magic: 0,
+///     },
+///     data: &mut[0; 12],
+/// };
+/// // wait for kernel events of type IRQ or IPC
+/// let _ = uapi::syscall::wait_for_event(
+///             uapi::systypes::EventType::IRQ.into() | uapi::systypes::EventType::Ipc.into(),
+///             0;
+///         );
+/// // get back event data from kernel
+/// let _ = my_event.from_kernel();
+/// // handle event
+/// if !my_event.header.is_valid() {
+///     return Err(),
+/// }
+/// match my_event.header.event {
+///     EventType::Irq => treat_irq(&my_event.data, my_event.length),
+///     EventType::IPC => treat_ipc(&my_event.data,  my_event.length),
+///     any_other      => Err(),
+/// }
+/// ```
+///
+
 impl SentryExchangeable for crate::systypes::Event<'_> {
 
     #[allow(static_mut_refs)]

--- a/uapi/src/exchange.rs
+++ b/uapi/src/exchange.rs
@@ -78,7 +78,6 @@ impl SentryExchangeable for crate::systypes::shm::ShmInfo {
 
 // from-exchange related capacity to Exchang header
 impl ExchangeHeader {
-
     unsafe fn from_addr(self, address: usize) -> &'static Self {
         &*(address as *const Self)
     }
@@ -96,8 +95,6 @@ impl ExchangeHeader {
     pub unsafe fn from_exchange_mut(self) -> &'static mut Self {
         self.from_addr_mut(EXCHANGE_AREA.as_mut_ptr() as usize)
     }
-
-
 }
 
 /// Event SentryExchangeable trait implementation
@@ -142,9 +139,7 @@ impl ExchangeHeader {
 /// }
 /// ```
 ///
-
 impl SentryExchangeable for crate::systypes::Event<'_> {
-
     #[allow(static_mut_refs)]
     fn from_kernel(&mut self) -> Result<Status, Status> {
         // declare exchange as header first
@@ -199,7 +194,8 @@ impl SentryExchangeable for crate::systypes::Event<'_> {
     #[allow(static_mut_refs)]
     fn to_kernel(&self) -> Result<Status, Status> {
         // copy exchange header to exhcange zone
-        let k_header: &mut ExchangeHeader = unsafe { ExchangeHeader::from_exchange_mut (self.header) };
+        let k_header: &mut ExchangeHeader =
+            unsafe { ExchangeHeader::from_exchange_mut(self.header) };
         let header_len = core::mem::size_of::<ExchangeHeader>() as usize;
         k_header.peer = self.header.peer;
         k_header.magic = self.header.magic;
@@ -211,7 +207,8 @@ impl SentryExchangeable for crate::systypes::Event<'_> {
         }
         unsafe {
             let data_addr = EXCHANGE_AREA.as_ptr() as usize + header_len;
-            let data_ptr = data_addr as *mut [u8; EXCHANGE_AREA_LEN - core::mem::size_of::<ExchangeHeader>()];
+            let data_ptr =
+                data_addr as *mut [u8; EXCHANGE_AREA_LEN - core::mem::size_of::<ExchangeHeader>()];
             core::ptr::copy_nonoverlapping(
                 self.data.as_ptr(),
                 data_ptr as *mut u8,
@@ -335,7 +332,7 @@ mod tests {
                 length: 12,
                 magic: 0x4242,
             },
-            data: &mut[ 0x42; 12 ],
+            data: &mut [0x42; 12],
         };
         let mut dst = crate::systypes::Event {
             header: ExchangeHeader {
@@ -344,12 +341,15 @@ mod tests {
                 length: 0,
                 magic: 0,
             },
-            data: &mut[0; 12],
+            data: &mut [0; 12],
         };
         assert_eq!(src.to_kernel(), Ok(Status::Ok));
         assert_eq!(dst.from_kernel(), Ok(Status::Ok));
         assert_eq!(src.header, dst.header);
-        assert_eq!(src.data[..src.header.length.into()], dst.data[..src.header.length.into()]);
+        assert_eq!(
+            src.data[..src.header.length.into()],
+            dst.data[..src.header.length.into()]
+        );
         let mut shorter_dst = crate::systypes::Event {
             header: ExchangeHeader {
                 peer: 0,
@@ -357,7 +357,7 @@ mod tests {
                 length: 0,
                 magic: 0,
             },
-            data: &mut[0; 8],
+            data: &mut [0; 8],
         };
         // dest that are not able to hold overall data must not generate panic
         assert_eq!(shorter_dst.from_kernel(), Err(Status::Invalid));

--- a/uapi/src/systypes.rs
+++ b/uapi/src/systypes.rs
@@ -623,15 +623,73 @@ mirror_enum! {
 /// a [`Status::Ok`] value.
 /// The kernel return data for a single event type at a time, store in event field,
 /// while wait_for_event() allows waiting for multiple event at a time.
+
+//#[derive(Debug, Copy, Clone, PartialEq)]
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 pub struct ExchangeHeader {
-    pub event: EventType,
+    pub event: u8,
     pub length: u8,
-    magic: u16,
+    pub magic: u16,
     pub peer: u32,
 }
 
+
+#[test]
+fn test_layout_exchange_header() {
+    const UNINIT: ::std::mem::MaybeUninit<ExchangeHeader> = ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
+    assert_eq!(
+        ::std::mem::size_of::<ExchangeHeader>(),
+        8usize,
+        concat!("Size of: ", stringify!(ExchangeHeader))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<ExchangeHeader>(),
+        4usize,
+        concat!("Alignment of ", stringify!(ExchangeHeader))
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((*ptr).event) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ExchangeHeader),
+            "::",
+            stringify!(event)
+        )
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((*ptr).length) as usize - ptr as usize },
+        1usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ExchangeHeader),
+            "::",
+            stringify!(length)
+        )
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((*ptr).magic) as usize - ptr as usize },
+        2usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ExchangeHeader),
+            "::",
+            stringify!(magic)
+        )
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((*ptr).peer) as usize - ptr as usize },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ExchangeHeader),
+            "::",
+            stringify!(peer)
+        )
+    );
+}
 
 impl ExchangeHeader {
 
@@ -662,10 +720,10 @@ impl ExchangeHeader {
 /// Event is SentryExchangeable, see [`crate::exchange::SentryExchangeable`] and
 /// the corresponding implementation for this struct for more information.
 ///
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug)]
 pub struct Event<'a> {
     pub header: ExchangeHeader,
-    pub data: &'a [u8],
+    pub data: &'a mut [u8],
 }
 
 /// Device related types definitions

--- a/uapi/src/systypes.rs
+++ b/uapi/src/systypes.rs
@@ -245,6 +245,7 @@ pub type StreamHandle = u32;
 /// As multiple events can be set at once, event field is using a
 /// bitfield model to keep C+Rust usage easy
 #[repr(C)]
+#[derive(Clone,PartialEq,Copy,Debug)]
 pub enum EventType {
     /// No event
     None = 0,
@@ -260,9 +261,18 @@ pub enum EventType {
     All = 15,
 }
 
-/// Event Type to register (u32) converter
-impl From<EventType> for u32 {
-    fn from(event: EventType) -> u32 {
+/// list of potential Event types, encoded as u8 to exchange with kernel
+///
+/// This value corresponds to a set of one or multiple EventType value, so
+/// that the job can wait for multiple events at a time.
+/// Events priority when returning from the kernel is described in the events
+/// chapter of the Sentry documentation.
+///
+pub type EventList = u8;
+
+
+impl From<EventType> for u8 {
+    fn from(event: EventType) -> u8 {
         match event {
             EventType::None => 0,
             EventType::Ipc => 1,
@@ -274,6 +284,19 @@ impl From<EventType> for u32 {
     }
 }
 
+impl From<u8> for EventType {
+    fn from(event: u8) -> EventType {
+        match event {
+            0 => EventType::None,
+            1 => EventType::Ipc,
+            2 => EventType::Signal,
+            4 => EventType::Irq,
+            8 => EventType::Dma,
+            15 => EventType::All,
+            _ => EventType::None,
+        }
+    }
+}
 /// Erase type that can be used to clear the SVC_Exchange.
 ///
 /// TODO: to be moved to svc_exchange module as used exclusively by
@@ -591,6 +614,58 @@ mirror_enum! {
         Microseconds,
         Milliseconds,
     }
+}
+
+
+/// Header received from the kernel when waiting for at one event type
+///
+/// Received when returning from [`crate::syscall::wait_for_event`] syscall with
+/// a [`Status::Ok`] value.
+/// The kernel return data for a single event type at a time, store in event field,
+/// while wait_for_event() allows waiting for multiple event at a time.
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct ExchangeHeader {
+    pub event: EventType,
+    pub length: u8,
+    magic: u16,
+    pub peer: u32,
+}
+
+
+impl ExchangeHeader {
+
+    pub fn is_valid(self) -> bool {
+        // TODO: hard-coded by now
+        self.magic == 0x4242
+    }
+
+    pub fn is_ipc(self) -> bool {
+        ((self.event as u8) & (EventType::Ipc as u8)) != EventType::None.into()
+    }
+
+    pub fn is_signal(self) -> bool {
+        ((self.event as u8) & (EventType::Signal as u8)) != EventType::None.into()
+    }
+
+    pub fn is_irq(self) -> bool {
+        ((self.event as u8) & (EventType::Irq as u8)) != EventType::None.into()
+    }
+
+    pub fn is_dma(self) -> bool {
+        ((self.event as u8) & (EventType::Dma as u8)) != EventType::None.into()
+    }
+}
+
+/// Typical Event received by the kernel using the copy_from_kernel(my_event)
+///
+/// Event is SentryExchangeable, see [`crate::exchange::SentryExchangeable`] and
+/// the corresponding implementation for this struct for more information.
+///
+#[derive(Debug, Copy, Clone)]
+pub struct Event<'a> {
+    pub header: ExchangeHeader,
+    pub data: &'a [u8],
 }
 
 /// Device related types definitions

--- a/uapi/src/systypes.rs
+++ b/uapi/src/systypes.rs
@@ -693,22 +693,6 @@ impl ExchangeHeader {
         // TODO: hard-coded by now
         self.magic == 0x4242
     }
-
-    pub fn is_ipc(self) -> bool {
-        ((self.event as u8) & (EventType::Ipc as u8)) != EventType::None.into()
-    }
-
-    pub fn is_signal(self) -> bool {
-        ((self.event as u8) & (EventType::Signal as u8)) != EventType::None.into()
-    }
-
-    pub fn is_irq(self) -> bool {
-        ((self.event as u8) & (EventType::Irq as u8)) != EventType::None.into()
-    }
-
-    pub fn is_dma(self) -> bool {
-        ((self.event as u8) & (EventType::Dma as u8)) != EventType::None.into()
-    }
 }
 
 /// Typical Event received by the kernel using the copy_from_kernel(my_event)

--- a/uapi/src/systypes.rs
+++ b/uapi/src/systypes.rs
@@ -245,7 +245,7 @@ pub type StreamHandle = u32;
 /// As multiple events can be set at once, event field is using a
 /// bitfield model to keep C+Rust usage easy
 #[repr(C)]
-#[derive(Clone,PartialEq,Copy,Debug)]
+#[derive(Clone, PartialEq, Copy, Debug)]
 pub enum EventType {
     /// No event
     None = 0,
@@ -269,7 +269,6 @@ pub enum EventType {
 /// chapter of the Sentry documentation.
 ///
 pub type EventList = u8;
-
 
 impl From<EventType> for u8 {
     fn from(event: EventType) -> u8 {
@@ -616,7 +615,6 @@ mirror_enum! {
     }
 }
 
-
 /// Header received from the kernel when waiting for at one event type
 ///
 /// Received when returning from [`crate::syscall::wait_for_event`] syscall with
@@ -633,7 +631,6 @@ pub struct ExchangeHeader {
     pub magic: u16,
     pub peer: u32,
 }
-
 
 #[test]
 fn test_layout_exchange_header() {
@@ -692,7 +689,6 @@ fn test_layout_exchange_header() {
 }
 
 impl ExchangeHeader {
-
     pub fn is_valid(self) -> bool {
         // TODO: hard-coded by now
         self.magic == 0x4242


### PR DESCRIPTION
- [x] Define event header and event structure that correspond to a kernel event
- [x] Support for Event reception from kernel
- [x] Support for Event data transmission when being and IPC

Note: Event reception/transmission are not syscall calls, but exchange interactions, meaning that a typical usage would
be :

```rust
let mut my_event = Event {
    header = ExchangeHeader {
        event = EventType::None,
        length = 0,
        peer = 0,
        magic = 0,
    },
    data = &[u8; 128],
}

let _ = syscall::wait_for_event(EventType::Ipc.into() | EventType::Irq.into(), 0);
// get back event from kernel, including data if needed
copy_from_kernel(my_event)?;

match event.header.event {
   EventType::Ipc => (),
   EventType::Irq => (),
   /// and so on
}
```