### PR TITLE
uapi,doc: fix concepts for new C uapi export

### DIFF
--- a/doc/concepts/tests/autotest.rst
+++ b/doc/concepts/tests/autotest.rst
@@ -201,7 +201,7 @@ A typical basic test looks like the following the following:
     TEST_START();
 
     micro_st = sys_get_cycle(PRECISION_MICROSECONDS);
-    copy_to_user((uint8_t*)&micro, sizeof(uint64_t));;
+    copy_from_kernel((uint8_t*)&micro, sizeof(uint64_t));;
 
     ASSERT_EQ(micro_st, STATUS_OK);
     ASSERT_GT((int)micro, 0);

--- a/doc/concepts/uapi/syscalls.rst
+++ b/doc/concepts/uapi/syscalls.rst
@@ -23,6 +23,9 @@ In the kernel counter part:
      also depend on `systypes`
 
 
+The UAPI description is made for C usage of the UAPI. For Rust definition, please
+refer to the Rust generated documentation.
+
 .. index::
   single: UAPI; syscalls
   single: UAPI; syscall definition

--- a/doc/concepts/uapi/syscalls/alarm.rst
+++ b/doc/concepts/uapi/syscalls/alarm.rst
@@ -5,17 +5,10 @@ sys_alarm
 
 **API definition**
 
-   .. code-block:: rust
-      :caption: Rust UAPI for alarm syscall
-
-      mod uapi {
-         fn alarm(timeout_ms: u32) -> Status
-      }
-
    .. code-block:: c
       :caption: C UAPI for alarm syscall
 
-      enum Status sys_alarm(uint32_t timeout_ms);
+      enum Status __sys_alarm(uint32_t timeout_ms);
 
 **Usage**
 
@@ -33,10 +26,10 @@ sys_alarm
       :linenos:
       :caption: sample bare usage of sys_alarm
 
-      if (sys_alarm(200) != STATUS_OKAY) {
+      if (__sys_alarm(200) != STATUS_OKAY) {
          // [...]
       }
-      res = sys_wait_event([...]);
+      res = __sys_wait_event([...]);
       /* alarm received 200ms later */
 
    .. note::

--- a/doc/concepts/uapi/syscalls/dma_assign_stream.rst
+++ b/doc/concepts/uapi/syscalls/dma_assign_stream.rst
@@ -4,17 +4,10 @@ sys_dma_assign_stream
 
 **API definition**
 
-   .. code-block:: rust
-      :caption: Rust UAPI for dma_assign_stream syscall
-
-      mod uapi {
-         fn dma_assign_stream(handle: dmah_t) -> Status
-      }
-
    .. code-block:: c
       :caption: C UAPI for dma_assign_stream syscall
 
-      enum Status sys_dma_assign_stream(dmah_t handle);
+      enum Status __sys_dma_assign_stream(dmah_t handle);
 
 **Usage**
 
@@ -53,7 +46,7 @@ sys_dma_assign_stream
       :linenos:
       :caption: sample DMA stream assignation
 
-      if (sys_dma_assign_stream(stream_handle) != STATUS_OK) {
+      if (__sys_dma_assign_stream(stream_handle) != STATUS_OK) {
          // the channel may be already assigned, unassign first
       }
 

--- a/doc/concepts/uapi/syscalls/dma_resume_stream.rst
+++ b/doc/concepts/uapi/syscalls/dma_resume_stream.rst
@@ -4,17 +4,10 @@ sys_dma_resume_stream
 
 **API definition**
 
-   .. code-block:: rust
-      :caption: Rust UAPI for dma_resume_stream syscall
-
-      mod uapi {
-         fn dma_resume_stream(handle: dmah_t) -> Status
-      }
-
    .. code-block:: c
       :caption: C UAPI for dma_resume_stream syscall
 
-      enum Status sys_dma_resume_stream(dmah_t handle);
+      enum Status __sys_dma_resume_stream(dmah_t handle);
 
 **Usage**
 
@@ -58,17 +51,17 @@ sys_dma_resume_stream
 
       #include <uapi.h>
 
-      if (sys_dma_start_stream(stream_handle) != STATUS_OK) {
+      if (__sys_dma_start_stream(stream_handle) != STATUS_OK) {
          // the channel may be already assigned, unassign first
       }
       // DMA behave in circular mode
 
-      if (sys_dma_suspend_stream(stream_handle) != STATUS_OK) {
+      if (__sys_dma_suspend_stream(stream_handle) != STATUS_OK) {
          // [...]
       }
       // working on DMA source or destination....
       // resume stream no that SW update is done
-      if (sys_dma_resume_stream(stream_handle) != STATUS_OK) {
+      if (__sys_dma_resume_stream(stream_handle) != STATUS_OK) {
          // [...]
       }
 

--- a/doc/concepts/uapi/syscalls/dma_start_stream.rst
+++ b/doc/concepts/uapi/syscalls/dma_start_stream.rst
@@ -4,17 +4,10 @@ sys_dma_start_stream
 
 **API definition**
 
-   .. code-block:: rust
-      :caption: Rust UAPI for dma_start_stream syscall
-
-      mod uapi {
-         fn dma_start_stream(handle: dmah_t) -> Status
-      }
-
    .. code-block:: c
       :caption: C UAPI for dma_start_stream syscall
 
-      enum Status sys_dma_start_stream(dmah_t handle);
+      enum Status __sys_dma_start_stream(dmah_t handle);
 
 **Usage**
 
@@ -59,10 +52,10 @@ sys_dma_start_stream
 
       #include <uapi.h>
 
-      if (sys_dma_start_stream(stream_handle) != STATUS_OK) {
+      if (__sys_dma_start_stream(stream_handle) != STATUS_OK) {
          // the channel may be already assigned, unassign first
       }
-      if (sys_wait_for_event(EVENT_TYPE_DMA, WFE_WAIT_FOREVER) != STATUS_OK) {
+      if (__sys_wait_for_event(EVENT_TYPE_DMA, WFE_WAIT_FOREVER) != STATUS_OK) {
          // error while waiting for DMA event
       }
       // handle DMA event corresponding to previously started DMA stream

--- a/doc/concepts/uapi/syscalls/dma_suspend_stream.rst
+++ b/doc/concepts/uapi/syscalls/dma_suspend_stream.rst
@@ -4,17 +4,10 @@ sys_dma_suspend_stream
 
 **API definition**
 
-   .. code-block:: rust
-      :caption: Rust UAPI for dma_suspend_stream syscall
-
-      mod uapi {
-         fn dma_suspend_stream(handle: dmah_t) -> Status
-      }
-
    .. code-block:: c
       :caption: C UAPI for dma_suspend_stream syscall
 
-      enum Status sys_dma_suspend_stream(dmah_t handle);
+      enum Status __sys_dma_suspend_stream(dmah_t handle);
 
 **Usage**
 
@@ -63,17 +56,17 @@ sys_dma_suspend_stream
 
       #include <uapi.h>
 
-      if (sys_dma_start_stream(stream_handle) != STATUS_OK) {
+      if (__sys_dma_start_stream(stream_handle) != STATUS_OK) {
          // the channel may be already assigned, unassign first
       }
       // DMA behave in circular mode
 
-      if (sys_dma_suspend_stream(stream_handle) != STATUS_OK) {
+      if (__sys_dma_suspend_stream(stream_handle) != STATUS_OK) {
          // [...]
       }
       // working on DMA source or destination....
       // resume stream no that SW update is done
-      if (sys_dma_resume_stream(stream_handle) != STATUS_OK) {
+      if (__sys_dma_resume_stream(stream_handle) != STATUS_OK) {
          // [...]
       }
 

--- a/doc/concepts/uapi/syscalls/dma_unassign_stream.rst
+++ b/doc/concepts/uapi/syscalls/dma_unassign_stream.rst
@@ -4,17 +4,10 @@ sys_dma_unassign_stream
 
 **API definition**
 
-   .. code-block:: rust
-      :caption: Rust UAPI for dma_unassign_stream syscall
-
-      mod uapi {
-         fn dma_unassign_stream(handle: dmah_t) -> Status
-      }
-
    .. code-block:: c
       :caption: C UAPI for dma_unassign_stream syscall
 
-      enum Status sys_dma_unassign_stream(dmah_t handle);
+      enum Status __sys_dma_unassign_stream(dmah_t handle);
 
 **Usage**
 
@@ -56,16 +49,16 @@ sys_dma_unassign_stream
       :linenos:
       :caption: sample DMA stream unassignation
 
-      if (sys_dma_start_stream(stream_handle) != STATUS_OK) {
+      if (__sys_dma_start_stream(stream_handle) != STATUS_OK) {
          // the channel may be already assigned, unassign first
       }
-      if (sys_wait_for_event(EVENT_TYPE_DMA, WFE_WAIT_FOREVER) != STATUS_OK) {
+      if (__sys_wait_for_event(EVENT_TYPE_DMA, WFE_WAIT_FOREVER) != STATUS_OK) {
          // error while waiting for DMA event
       }
       // handle DMA event corresponding to previously started DMA stream
 
       // unasign stream if Transfer Complete event received
-      if (sys_dma_unassigned_stream(stream_handle) != STATUS_OK) {
+      if (__sys_dma_unassigned_stream(stream_handle) != STATUS_OK) {
          // the channel may be already assigned, unassign first
       }
 

--- a/doc/concepts/uapi/syscalls/exit.rst
+++ b/doc/concepts/uapi/syscalls/exit.rst
@@ -3,17 +3,10 @@ sys_exit
 
 **API definition**
 
-   .. code-block:: rust
-      :caption: Rust UAPI for exit syscall
-
-      mod uapi {
-         fn exit(status: u32) -> Status
-      }
-
    .. code-block:: c
       :caption: C UAPI for exit syscall
 
-      enum Status sys_exit(uint32_t status);
+      enum Status __sys_exit(uint32_t status);
 
 
 **Usage**

--- a/doc/concepts/uapi/syscalls/get_dev_handle.rst
+++ b/doc/concepts/uapi/syscalls/get_dev_handle.rst
@@ -4,17 +4,10 @@ sys_get_device_handle
 
 **API definition**
 
-   .. code-block:: rust
-      :caption: Rust UAPI for get_task_handle syscall
-
-      mod uapi {
-         fn get_device_handle(dev_label: u32) -> Status
-      }
-
    .. code-block:: c
       :caption: C UAPI for get_task_handle syscall
 
-      enum Status sys_get_device_handle(uint32_t dev_label);
+      enum Status __sys_get_device_handle(uint32_t dev_label);
 
 **Usage**
 
@@ -41,10 +34,10 @@ sys_get_device_handle
 
       uint32_t my_dev_label = devinfo[MYDEVICE].id;
       devh_t my_dev_handle;
-      if (sys_get_device_handle(my_dev_label) != STATUS_OK) {
+      if (__sys_get_device_handle(my_dev_label) != STATUS_OK) {
          // [...]
       }
-      copy_to_user(&my_dev_handle, sizeof(devh_t));
+      copy_from_kernel(&my_dev_handle, sizeof(devh_t));
 
 **Required capability**
 

--- a/doc/concepts/uapi/syscalls/get_dma_stream_handle.rst
+++ b/doc/concepts/uapi/syscalls/get_dma_stream_handle.rst
@@ -4,17 +4,10 @@ sys_get_dma_handle
 
 **API definition**
 
-   .. code-block:: rust
-      :caption: Rust UAPI for get_dma_stream_handle syscall
-
-      mod uapi {
-         fn get_dma_stream_handle(label: u32) -> Status
-      }
-
    .. code-block:: c
       :caption: C UAPI for get_dma_stream_handle syscall
 
-      enum Status sys_get_dma_stream_handle(uint32_t label);
+      enum Status __sys_get_dma_stream_handle(uint32_t label);
 
 **Usage**
 
@@ -37,10 +30,10 @@ sys_get_dma_handle
 
       uint32_t my_stream_label = 0x42;
       dmah_t my_stream_handle;
-      if (sys_get_dma_stream_handle(my_dma_label) != STATUS_OK) {
+      if (__sys_get_dma_stream_handle(my_dma_label) != STATUS_OK) {
          // [...]
       }
-      copy_to_user(&my_dma_handle, sizeof(devh_t));
+      copy_from_kernel(&my_dma_handle, sizeof(devh_t));
 
 **Required capability**
 

--- a/doc/concepts/uapi/syscalls/get_random.rst
+++ b/doc/concepts/uapi/syscalls/get_random.rst
@@ -3,17 +3,10 @@ sys_get_random
 
 **API definition**
 
-   .. code-block:: rust
-      :caption: Rust UAPI for get_random syscall
-
-      mod uapi {
-         fn get_random() -> Status
-      }
-
    .. code-block:: c
       :caption: C UAPI for get_random syscall
 
-      enum Status sys_get_random(void);
+      enum Status __sys_get_random(void);
 
 **Usage**
 
@@ -28,7 +21,7 @@ sys_get_random
       :caption: sample bare usage of sys_log
 
       uint32_t seed = 0;
-      if (sys_get_random() != STATUS_OK) {
+      if (__sys_get_random() != STATUS_OK) {
          // [...]
       }
       memcpy(&seed, _s_svc_exchange, sizeof(uint32_t));

--- a/doc/concepts/uapi/syscalls/get_shm_handle.rst
+++ b/doc/concepts/uapi/syscalls/get_shm_handle.rst
@@ -4,17 +4,10 @@ sys_get_shm_handle
 
 **API definition**
 
-   .. code-block:: rust
-      :caption: Rust UAPI for get_shm_handle syscall
-
-      mod uapi {
-         fn get_shm_handle(label: u32) -> Status
-      }
-
    .. code-block:: c
       :caption: C UAPI for get_shm_handle syscall
 
-      enum Status sys_get_shm_handle(uint32_t label);
+      enum Status __sys_get_shm_handle(uint32_t label);
 
 **Usage**
 
@@ -38,10 +31,10 @@ sys_get_shm_handle
 
       uint32_t my_peer_label=0xbabe;
       taskh_t my_peer_handle;
-      if (sys_get_shm_handle(my_shm_label) != STATUS_OK) {
+      if (__sys_get_shm_handle(my_shm_label) != STATUS_OK) {
          // [...]
       }
-      copy_to_user(&my_peer_handle, sizeof(shmh_t));
+      __copy_from_kernel(&my_peer_handle, sizeof(shmh_t));
 
 **Required capability**
 

--- a/doc/concepts/uapi/syscalls/get_shm_handle.rst
+++ b/doc/concepts/uapi/syscalls/get_shm_handle.rst
@@ -34,7 +34,7 @@ sys_get_shm_handle
       if (__sys_get_shm_handle(my_shm_label) != STATUS_OK) {
          // [...]
       }
-      __copy_from_kernel(&my_peer_handle, sizeof(shmh_t));
+      copy_from_kernel(&my_peer_handle, sizeof(shmh_t));
 
 **Required capability**
 

--- a/doc/concepts/uapi/syscalls/get_task_handle.rst
+++ b/doc/concepts/uapi/syscalls/get_task_handle.rst
@@ -4,17 +4,10 @@ sys_get_task_handle
 
 **API definition**
 
-   .. code-block:: rust
-      :caption: Rust UAPI for get_task_handle syscall
-
-      mod uapi {
-         fn get_task_handle(label: u32) -> Status
-      }
-
    .. code-block:: c
       :caption: C UAPI for get_task_handle syscall
 
-      enum Status sys_get_task_handle(uint32_t label);
+      enum Status __sys_get_task_handle(uint32_t label);
 
 **Usage**
 
@@ -47,11 +40,11 @@ sys_get_task_handle
 
       uint32_t my_peer_label=0xbabe;
       taskh_t my_peer_handle;
-      if (sys_get_handle(my_peer_label) != STATUS_OK) {
+      if (__sys_get_handle(my_peer_label) != STATUS_OK) {
          // [...]
       }
-      copy_to_user(&my_peer_handle, sizeof(taskh_t));
-      sys_send_signal(my_peer_handle, SIGNAL_POLL);
+      copy_from_kernel(&my_peer_handle, sizeof(taskh_t));
+      __sys_send_signal(my_peer_handle, SIGNAL_POLL);
 
 **Required capability**
 

--- a/doc/concepts/uapi/syscalls/gpio_get.rst
+++ b/doc/concepts/uapi/syscalls/gpio_get.rst
@@ -3,17 +3,10 @@ sys_gpio_get
 
 **API definition**
 
-   .. code-block:: rust
-      :caption: Rust UAPI for gpio_get syscall
-
-      mod uapi {
-         fn gpio_get(device: devh_t, io_identifier: u8) -> Status
-      }
-
    .. code-block:: c
       :caption: C UAPI for gpio_get syscall
 
-      enum Status sys_gpio_get(devh_t device, uint8_t io_identifier);
+      enum Status __sys_gpio_get(devh_t device, uint8_t io_identifier);
 
 **Usage**
 
@@ -43,10 +36,10 @@ sys_gpio_get
       :linenos:
       :caption: getting I/O 0 from button
 
-      if (sys_gpio_get(myhandle, 0) != STATUS_OK) {
+      if (__sys_gpio_get(myhandle, 0) != STATUS_OK) {
          // [...]
       }
-      copy_to_user(uint8_t *button_value, sizeof(uint8_t));
+      copy_from_kernel(uint8_t *button_value, sizeof(uint8_t));
 
 **Required capability**
 

--- a/doc/concepts/uapi/syscalls/gpio_reset.rst
+++ b/doc/concepts/uapi/syscalls/gpio_reset.rst
@@ -3,17 +3,10 @@ sys_gpio_reset
 
 **API definition**
 
-   .. code-block:: rust
-      :caption: Rust UAPI for gpio_reset syscall
-
-      mod uapi {
-         fn gpio_reset(device: devh_t, io_identifier: u8) -> Status
-      }
-
    .. code-block:: c
       :caption: C UAPI for gpio_reset syscall
 
-      enum Status sys_gpio_reset(devh_t device, uint8_t io_identifier);
+      enum Status __sys_gpio_reset(devh_t device, uint8_t io_identifier);
 
 **Usage**
 
@@ -43,7 +36,7 @@ sys_gpio_reset
       :linenos:
       :caption: getting I/O 0 from button
 
-      if (sys_gpio_reset(myhandle, 0) != STATUS_OK) {
+      if (__sys_gpio_reset(myhandle, 0) != STATUS_OK) {
          // [...]
       }
 

--- a/doc/concepts/uapi/syscalls/gpio_set.rst
+++ b/doc/concepts/uapi/syscalls/gpio_set.rst
@@ -3,17 +3,10 @@ sys_gpio_set
 
 **API definition**
 
-   .. code-block:: rust
-      :caption: Rust UAPI for gpio_set syscall
-
-      mod uapi {
-         fn gpio_set(device: devh_t, io_identifier: u8, value: bool) -> Status
-      }
-
    .. code-block:: c
       :caption: C UAPI for gpio_set syscall
 
-      enum Status sys_gpio_set(devh_t device, uint8_t io_identifier, bool value);
+      enum Status __sys_gpio_set(devh_t device, uint8_t io_identifier, bool value);
 
 **Usage**
 
@@ -43,7 +36,7 @@ sys_gpio_set
       :linenos:
       :caption: setting I/O 0 (fist element of the pinctrl)
 
-      if (sys_gpio_set(myhandle, 0, 1) != STATUS_OK) {
+      if (__sys_gpio_set(myhandle, 0, 1) != STATUS_OK) {
          // [...]
       }
 

--- a/doc/concepts/uapi/syscalls/gpio_toggle.rst
+++ b/doc/concepts/uapi/syscalls/gpio_toggle.rst
@@ -3,17 +3,10 @@ sys_gpio_toggle
 
 **API definition**
 
-   .. code-block:: rust
-      :caption: Rust UAPI for gpio_toggle syscall
-
-      mod uapi {
-         fn gpio_toggle(device: devh_t, io_identifier: u8) -> Status
-      }
-
    .. code-block:: c
       :caption: C UAPI for gpio_set syscall
 
-      enum Status sys_gpio_toggle(devh_t device, uint8_t io_identifier);
+      enum Status __sys_gpio_toggle(devh_t device, uint8_t io_identifier);
 
 **Usage**
 
@@ -43,7 +36,7 @@ sys_gpio_toggle
       :linenos:
       :caption: toggling I/O 0 (fist element of the pinctrl)
 
-      if (sys_gpio_toggle(myhandle, 0) != STATUS_OK) {
+      if (__sys_gpio_toggle(myhandle, 0) != STATUS_OK) {
          // [...]
       }
 

--- a/doc/concepts/uapi/syscalls/irq_acknowledge.rst
+++ b/doc/concepts/uapi/syscalls/irq_acknowledge.rst
@@ -3,17 +3,10 @@ sys_irq_acknowledge
 
 **API definition**
 
-   .. code-block:: rust
-      :caption: Rust UAPI for irq_acknowledge syscall
-
-      mod uapi {
-         fn irq_acknowledge(irq: u16) -> Status
-       }
-
    .. code-block:: c
       :caption: C UAPI for irq_acknowledge syscall
 
-      enum Status sys_irq_acknowledge(uint16_t IRQn);
+      enum Status __sys_irq_acknowledge(uint16_t IRQn);
 
 **Usage**
 
@@ -31,7 +24,7 @@ sys_irq_acknowledge
       int my_handler(uint16_t IRQn) {
          // executing the handler
          // [...]
-         if (sys_irq_acknowledge(myIRQn) != STATUS_OK) {
+         if (__sys_irq_acknowledge(myIRQn) != STATUS_OK) {
             // [...]
          }
          // [...]

--- a/doc/concepts/uapi/syscalls/irq_disable.rst
+++ b/doc/concepts/uapi/syscalls/irq_disable.rst
@@ -3,17 +3,10 @@ sys_irq_disable
 
 **API definition**
 
-   .. code-block:: rust
-      :caption: Rust UAPI for irq_disable syscall
-
-      mod uapi {
-         fn irq_disable(irq: u16) -> Status
-       }
-
    .. code-block:: c
       :caption: C UAPI for irq_disable syscall
 
-      enum Status sys_irq_disable(uint16_t IRQn);
+      enum Status __sys_irq_disable(uint16_t IRQn);
 
 **Usage**
 
@@ -38,7 +31,7 @@ sys_irq_disable
       :linenos:
       :caption: disable given IRQ of an owned device
 
-      if (sys_irq_disable(myIRQn) != STATUS_OK) {
+      if (__sys_irq_disable(myIRQn) != STATUS_OK) {
             // [...]
       }
 

--- a/doc/concepts/uapi/syscalls/irq_enable.rst
+++ b/doc/concepts/uapi/syscalls/irq_enable.rst
@@ -3,17 +3,10 @@ sys_irq_enable
 
 **API definition**
 
-   .. code-block:: rust
-      :caption: Rust UAPI for irq_enable syscall
-
-      mod uapi {
-         fn irq_enable(irq: u16) -> Status
-       }
-
    .. code-block:: c
       :caption: C UAPI for irq_enable syscall
 
-      enum Status sys_irq_enable(uint16_t IRQn);
+      enum Status __sys_irq_enable(uint16_t IRQn);
 
 **Usage**
 
@@ -41,7 +34,7 @@ sys_irq_enable
 
       // configure the device (and device-relative IRQ config)
       // [...]
-      if (sys_irq_enable(myIRQn) != STATUS_OK) {
+      if (__sys_irq_enable(myIRQn) != STATUS_OK) {
             // [...]
       }
 

--- a/doc/concepts/uapi/syscalls/log.rst
+++ b/doc/concepts/uapi/syscalls/log.rst
@@ -3,17 +3,10 @@ sys_log
 
 **API definition**
 
-   .. code-block:: rust
-      :caption: Rust UAPI for log syscall
-
-      mod uapi {
-         fn log(length: usize) -> Status
-      }
-
    .. code-block:: c
       :caption: C UAPI for log syscall
 
-      enum Status sys_log(size_t length);
+      enum Status __sys_log(size_t length);
 
 **Usage**
 
@@ -30,7 +23,7 @@ sys_log
       enum Status res = STATUS_INVALID;
       if (len <=> CONFIG_SVC_EXCHANGE_AREA_LEN) {
          memcpy(&_s_svc_exchange, data, len);
-         res = sys_log(len);
+         res = __sys_log(len);
       }
 
    .. note::

--- a/doc/concepts/uapi/syscalls/map.rst
+++ b/doc/concepts/uapi/syscalls/map.rst
@@ -3,19 +3,11 @@ sys_map_dev
 
 **API definition**
 
-   .. code-block:: rust
-      :caption: Rust UAPI for device mapping syscall
-
-      mod uapi {
-         fn map_dev(devh: dev_handle) -> Status
-         fn unmap_dev(devh: dev_handle) -> Status
-      }
-
    .. code-block:: c
       :caption: C UAPI for device mapping syscall
 
-      enum Status sys_map_dev(devh_t dev);
-      enum Status sys_unmap_dev(devh_t dev);
+      enum Status __sys_map_dev(devh_t dev);
+      enum Status __sys_unmap_dev(devh_t dev);
 
 **Usage**
 
@@ -39,7 +31,7 @@ sys_map_dev
       devh_t mydriver_handle = mydriver_get_handle();
       res = sys_map_dev(mydriver_handle);
       // manipulating device registers.....
-      res = sys_unmap_dev(mydriver_handle);
+      res = __sys_unmap_dev(mydriver_handle);
 
    .. note::
       the libShield libc typically delivers a mmap() implementation with, for

--- a/doc/concepts/uapi/syscalls/pm_clock_set.rst
+++ b/doc/concepts/uapi/syscalls/pm_clock_set.rst
@@ -3,17 +3,10 @@ sys_pm_clock_set
 
 **API definition**
 
-   .. code-block:: rust
-      :caption: Rust UAPI for pm_clock_gate syscall
-
-      mod uapi {
-         fn pm_clock_set(clk_reg_offset: u32, clk_reg_value: u32) -> Status
-      }
-
    .. code-block:: c
       :caption: C UAPI for pm_clock_set syscall
 
-      enum Status sys_pm_clock_set(uint32_t reg_offset, uint32_t reg_value);
+      enum Status __sys_pm_clock_set(uint32_t reg_offset, uint32_t reg_value);
 
 **Usage**
 

--- a/doc/concepts/uapi/syscalls/send_ipc.rst
+++ b/doc/concepts/uapi/syscalls/send_ipc.rst
@@ -4,17 +4,10 @@ sys_send_ipc
 
 **API definition**
 
-   .. code-block:: rust
-       :caption: Rust UAPI for send_ipc syscall
-
-       mod uapi {
-           fn send_ipc(target: taskh_t, len: u32) -> Status
-       }
-
    .. code-block:: c
        :caption: C UAPI for send_ipc syscall
 
-       enum Status sys_send_ipc(taskh_t target, uint32_t len);
+       enum Status __sys_send_ipc(taskh_t target, uint32_t len);
 
 **Usage**
 

--- a/doc/concepts/uapi/syscalls/send_signal.rst
+++ b/doc/concepts/uapi/syscalls/send_signal.rst
@@ -3,17 +3,10 @@ sys_send_signal
 
 **API definition**
 
-   .. code-block:: rust
-      :caption: Rust UAPI for send_signal syscall
-
-      mod uapi {
-         fn send_signal(target: taskh_t, signal: uapi::Signal) -> Status
-      }
-
    .. code-block:: c
       :caption: C UAPI for send_signal syscall
 
-      enum Status sys_send_signal(taskh_t target, enum Signal signal);
+      enum Status __sys_send_signal(taskh_t target, enum Signal signal);
 
 **Usage**
 
@@ -38,7 +31,7 @@ sys_send_signal
       :caption: sample bare usage of sys_send_signal
 
       uint32_t seed = 0;
-      if (sys_send_signal(target, SIGNAL_USR1) != STATUS_OK) {
+      if (__sys_send_signal(target, SIGNAL_USR1) != STATUS_OK) {
          // [...]
       }
 

--- a/doc/concepts/uapi/syscalls/shm_get_infos.rst
+++ b/doc/concepts/uapi/syscalls/shm_get_infos.rst
@@ -4,17 +4,10 @@ sys_shm_get_infos
 
 **API definition**
 
-   .. code-block:: rust
-      :caption: Rust UAPI for shm_get_infos syscall
-
-      mod uapi {
-         fn shm_get_infos(shm: shm_t) -> Status
-      }
-
    .. code-block:: c
       :caption: C UAPI for shm_get_infos syscall
 
-      enum Status sys_shm_get_infos(shmh_t shm);
+      enum Status __sys_shm_get_infos(shmh_t shm);
 
 **Usage**
 
@@ -56,19 +49,19 @@ sys_shm_get_infos
       uint32_t my_shm_label=0xf00UL;
       taskh_t myself;
       shm_infos_t infos;
-      if (sys_get_task_handle(myself_label) != STATUS_OK) {
+      if (__sys_get_task_handle(myself_label) != STATUS_OK) {
          // [...]
       }
-      copy_to_user(&myself, sizeof(taskh_t));
-      if (sys_get_shm_handle(my_shm_label) != STATUS_OK) {
+      copy_from_kernel(&myself, sizeof(taskh_t));
+      if (__sys_get_shm_handle(my_shm_label) != STATUS_OK) {
          // [...]
       }
-      copy_to_user(&my_shm_handle, sizeof(shmh_t));
+      copy_from_kernel(&my_shm_handle, sizeof(shmh_t));
 
-      if (sys_shm_get_infos(my_shm_handle)) {
+      if (__sys_shm_get_infos(my_shm_handle)) {
         // [...]
       }
-      copy_to_user(&infos, sizeof(shm_infos_t));
+      copy_from_kernel(&infos, sizeof(shm_infos_t));
       printf("SHM base address is %lx\n", infos.base);
 
 **Required capability**

--- a/doc/concepts/uapi/syscalls/shm_map.rst
+++ b/doc/concepts/uapi/syscalls/shm_map.rst
@@ -3,19 +3,11 @@ sys_map_shm
 
 **API definition**
 
-   .. code-block:: rust
-      :caption: Rust UAPI for SHM mapping syscall
-
-      mod uapi {
-         fn map_shm(shmh: shmh_t) -> Status
-         fn unmap_shm(shmh: shmh_t) -> Status
-      }
-
    .. code-block:: c
       :caption: C UAPI for device mapping syscall
 
-      enum Status sys_map_shm(shmh_t shm);
-      enum Status sys_unmap_shm(shmh_t shm);
+      enum Status __sys_map_shm(shmh_t shm);
+      enum Status __sys_unmap_shm(shmh_t shm);
 
 **Usage**
 
@@ -32,10 +24,10 @@ sys_map_shm
       shmh_t shm;
       uint32_t shm_label = 0xf00UL;
 
-      if (sys_get_shmhandle(shm_label) != STATUS_OK) {
+      if (__sys_get_shmhandle(shm_label) != STATUS_OK) {
          // [...]
       }
-      res = sys_map_shm(shm_label);
+      res = __sys_map_shm(shm_label);
 
    .. note::
       the SHM credential must be set through `sys_shm_set_credential()` in order to be allowed to map the SHM.

--- a/doc/concepts/uapi/syscalls/shm_set_credential.rst
+++ b/doc/concepts/uapi/syscalls/shm_set_credential.rst
@@ -4,17 +4,10 @@ sys_shm_set_credential
 
 **API definition**
 
-   .. code-block:: rust
-      :caption: Rust UAPI for shm_set_crendential syscall
-
-      mod uapi {
-         fn shm_set_credential(shm: shm_t, target: taskh_t, shm_perm: u32) -> Status
-      }
-
    .. code-block:: c
       :caption: C UAPI for shm_set_crendential syscall
 
-      enum Status sys_get_shm_handle(shmh_t shm, taskh_t target, uint32_t perms);
+      enum Status __sys_get_shm_handle(shmh_t shm, taskh_t target, uint32_t perms);
 
 **Usage**
 
@@ -59,16 +52,16 @@ sys_shm_set_credential
 
       uint32_t my_shm_label=0xf00UL;
       taskh_t myself;
-      if (sys_get_task_handle(myself_label) != STATUS_OK) {
+      if (__sys_get_task_handle(myself_label) != STATUS_OK) {
          // [...]
       }
-      copy_to_user(&myself, sizeof(taskh_t));
-      if (sys_get_shm_handle(my_shm_label) != STATUS_OK) {
+      copy_from_kernel(&myself, sizeof(taskh_t));
+      if (__sys_get_shm_handle(my_shm_label) != STATUS_OK) {
          // [...]
       }
-      copy_to_user(&my_shm_handle, sizeof(shmh_t));
+      copy_from_kernel(&my_shm_handle, sizeof(shmh_t));
 
-      sys_shm_set_credential(my_shm_handle, myself, SHM_PERMISSION_MAP | SHM_PERMISSION_WRITE);
+      __sys_shm_set_credential(my_shm_handle, myself, SHM_PERMISSION_MAP | SHM_PERMISSION_WRITE);
 
 **Required capability**
 

--- a/doc/concepts/uapi/syscalls/shm_unmap.rst
+++ b/doc/concepts/uapi/syscalls/shm_unmap.rst
@@ -3,19 +3,11 @@ sys_unmap_shm
 
 **API definition**
 
-   .. code-block:: rust
-      :caption: Rust UAPI for SHM mapping syscall
-
-      mod uapi {
-         fn map_shm(shmh: shmh_t) -> Status
-         fn unmap_shm(shmh: shmh_t) -> Status
-      }
-
    .. code-block:: c
       :caption: C UAPI for device mapping syscall
 
-      enum Status sys_map_shm(shmh_t shm);
-      enum Status sys_unmap_shm(shmh_t shm);
+      enum Status __sys_map_shm(shmh_t shm);
+      enum Status __sys_unmap_shm(shmh_t shm);
 
 **Usage**
 
@@ -32,10 +24,10 @@ sys_unmap_shm
       shmh_t shm;
       uint32_t shm_label = 0xf00UL;
 
-      if (sys_get_shmhandle(shm_label) != STATUS_OK) {
+      if (__sys_get_shmhandle(shm_label) != STATUS_OK) {
          // [...]
       }
-      res = sys_map_shm(shm_label);
+      res = __sys_map_shm(shm_label);
 
    .. note::
       the SHM credential must be set through `sys_shm_set_credential()` in order to be allowed to map the SHM.
@@ -49,14 +41,14 @@ sys_unmap_shm
 
 **Return values**
 
-   For `sys_shm_map()`:
+   For `__sys_shm_map()`:
 
       * STATUS_INVALID if the SHM handle do not exist or is not associated at all to the calling task
       * STATUS_DENIED if the SHM credential do not allow mapping
       * STATUS_ALREADY_MAPPED if SHM is already mapped
       * STATUS_OK
 
-   For `sys_shm_unmap()`:
+   For `__sys_shm_unmap()`:
 
       * STATUS_INVALID if the SHM handle do not exist or is not mapped
       * STATUS_OK

--- a/doc/concepts/uapi/syscalls/waitforevent.rst
+++ b/doc/concepts/uapi/syscalls/waitforevent.rst
@@ -6,13 +6,6 @@ sys_wait_for_event
 
 **API definition**
 
-   .. code-block:: rust
-      :caption: Rust UAPI for wait_for_event syscall
-
-      mod uapi {
-         fn wait_for_event(mask: u8, timeout: i32) -> Status
-      }
-
    .. code-block:: c
       :caption: C UAPI for wait_for_event syscall
 
@@ -25,7 +18,7 @@ sys_wait_for_event
         EVENT_TYPE_ALL = 0xf,
       } EventType;
 
-      enum Status sys_wait_for_event(uint8_t mask, int32_t timeout);
+      enum Status __sys_wait_for_event(uint8_t mask, int32_t timeout);
 
 **Usage**
 
@@ -115,7 +108,7 @@ sys_wait_for_event
       :caption: Typicall wait_for_event usage
 
       exchange_event_t * event = NULL;
-      status = wait_for_event(EVENT_TYPE_IPC | EVENT_TYPE_SIGNAL, WFE_WAIT_NO);
+      status = __sys_wait_for_event(EVENT_TYPE_IPC | EVENT_TYPE_SIGNAL, WFE_WAIT_NO);
       switch (status) {
          case STATUS_OKAY:
             /* an IPC or signal is received */


### PR DESCRIPTION
Update syscalls documentation for C interface to take into account the new ffi_c formalism.
Remove Rust code examples, as these examples are hold by Rust doc directly, now that the rust doc target is delivered as installable by the build system.