### PR TITLE
stm32, rcc: enhanced his48 handling

### DIFF
--- a/kernel/src/drivers/clk/stm32-rcc.c.in
+++ b/kernel/src/drivers/clk/stm32-rcc.c.in
@@ -111,6 +111,22 @@ __STATIC_INLINE kstatus_t rcc_enable_hse(void)
     return iopoll32_until_set(RCC_BASE_ADDR + RCC_CR_REG, RCC_CR_HSERDY, HSE_STARTUP_TIMEOUT);
 }
 
+#if defined(HAS_HSI48_CLOCK)
+__STATIC_INLINE kstatus_t rcc_enable_hsi48(void)
+{
+    kstatus_t status = K_STATUS_OKAY;
+    uint32_t reg;
+
+    reg = ioread32(RCC_BASE_ADDR + RCC_HSI48_REG);
+    reg |= RCC_HSI48ON;
+    iowrite32(RCC_BASE_ADDR + RCC_HSI48_REG, reg);
+
+    return iopoll32_until_set(RCC_BASE_ADDR + RCC_HSI48_REG, RCC_HSI48RDY, 500);
+}
+#endif /* RCC_CR_HSI48ON */
+
+
+
 /**
  * @brief Convert AHB divisor (power of 2) to register value
  *
@@ -217,6 +233,13 @@ __STATIC_INLINE kstatus_t rcc_init_system_clk(void)
 
     {%- if dts.clocks.clk_hsi.status == "okay" %}
     status = rcc_enable_hsi();
+    if (unlikely(status != K_STATUS_OKAY)) {
+        goto err;
+    }
+    {%- endif %}
+
+    {%- if dts.clocks.clk_hsi48 is defined and dts.clocks.clk_hsi48.status == "okay" %}
+    status = rcc_enable_hsi48();
     if (unlikely(status != K_STATUS_OKAY)) {
         goto err;
     }

--- a/kernel/src/drivers/clk/stm32l4-rcc.h.in
+++ b/kernel/src/drivers/clk/stm32l4-rcc.h.in
@@ -71,6 +71,16 @@
  */
 #define RCC_CIR_REG RCC_CICR_REG
 
+/*
+ * For stm32l496/4a6 subfamily, HSI48 control is held by CRRCR register
+ */
+#if defined(CONFIG_SOC_SUBFAMILY_STM32L49_Ax)
+#define HAS_HSI48_CLOCK
+#define RCC_HSI48_REG RCC_CRRCR_REG
+#define RCC_HSI48ON RCC_CRRCR_HSI48ON
+#define RCC_HSI48RDY RCC_CRRCR_HSI48RDY
+#endif
+
 {#- There is only one main PLL for stm32f4xx families #}
 {%- set pll = dts.get_compatible("st,stm32l4xx-pll")[0] %}
 {%- if pll is not none and pll.status == "okay"%}

--- a/kernel/src/drivers/clk/stm32u5-rcc.c
+++ b/kernel/src/drivers/clk/stm32u5-rcc.c
@@ -161,14 +161,6 @@ kstatus_t rcc_enable_pll(void)
     stm32u5_enable_pll_p_output(PLL_ID_3);
     stm32u5_enable_pll_r_output(PLL_ID_3);
 
-    /*
-     * Fixme:
-     *  Ugly hack, force HSI48 ON, this is used by RNG as clock source.
-     *  Remove this while outpost/sentry-kernel/issues/253 outpost/sentry-kernel/issues/254
-     *  are fixed/closed.
-     */
-    rcc_enable_hsi48();
-
     return K_STATUS_OKAY;
 }
 

--- a/kernel/src/drivers/clk/stm32u5-rcc.h.in
+++ b/kernel/src/drivers/clk/stm32u5-rcc.h.in
@@ -49,6 +49,14 @@
 #define RCC_APB2_BUS_FREQUENCY_MAX RCC_SYSCLOCK_FREQUENCY_MAX
 #define RCC_APB3_BUS_FREQUENCY_MAX RCC_SYSCLOCK_FREQUENCY_MAX
 
+/*
+ * For stm32u5 family, HSI48 control is held by CR register
+ */
+#define HAS_HSI48_CLOCK
+#define RCC_HSI48_REG RCC_CR_REG
+#define RCC_HSI48ON RCC_CR_HSI48ON
+#define RCC_HSI48RDY RCC_CR_HSI48RDY
+
 typedef enum stm32u5_pll_id {
     PLL_ID_1 = 0,
     PLL_ID_2 = 1,
@@ -102,18 +110,6 @@ static inline  void __stm32_rcc_set_peripheral_bus_div(
     cfgr3.raw = ioread32(RCC_BASE_ADDR + RCC_CFGR3_REG);
     cfgr3.reg.ppre3 = ppre3;
     iowrite32(RCC_BASE_ADDR + RCC_CFGR3_REG, cfgr3.raw);
-}
-
-static inline kstatus_t rcc_enable_hsi48(void)
-{
-    kstatus_t status = K_STATUS_OKAY;
-    uint32_t rcc_cr;
-
-    rcc_cr = ioread32(RCC_BASE_ADDR + RCC_CR_REG);
-    rcc_cr |= RCC_CR_HSI48ON;
-    iowrite32(RCC_BASE_ADDR + RCC_CR_REG, rcc_cr);
-
-    return iopoll32_until_set(RCC_BASE_ADDR + RCC_CR_REG, RCC_CR_HSI48RDY, 500);
 }
 
 kstatus_t rcc_select_system_clock(void);


### PR DESCRIPTION
hsi48 is not driven the same way according to soc family:
 - stm32u5 use RCC_RC register
 - stm32l496/4a6 use RCC_CRRCR register