### PR TITLE
arch,cortex-m: add stm32h573 to kconfig entry

### DIFF
--- a/kernel/src/arch/asm-cortex-m/Kconfig
+++ b/kernel/src/arch/asm-cortex-m/Kconfig
@@ -16,6 +16,7 @@ config ARCH_ARM_ARMV7EM
 	select ARCH_ARM_ARMV7M
 	select HAS_DSP
 
+# Note: MPU is optional for ARMv8m
 config ARCH_ARM_ARMV8M
 	bool
 	select HAS_MPU
@@ -146,6 +147,19 @@ config SOC_SUBFAMILY_STM32L4
 	help
 	  STM32L4 family is based on Cortex-M4 with FPU and PMSAv7 MPU with low power features
 
+config SOC_SUBFAMILY_STM32H5
+	bool
+	select SOC_FAMILY_STM32
+	select ARCH_ARM_CORTEX_M33
+	select HAS_FPU
+	select HAS_FPU_FPV5
+	select HAS_TRUSTZONE
+	select HAS_RNG
+	select HAS_DCACHE
+	select HAS_ICACHE
+	help
+	  STM32H5 family is based on Cortex-M33 with FPU, PMSAv8 MPU and TrustZone.
+
 config SOC_SUBFAMILY_STM32U5
 	bool
 	select ARCH_ARM_CORTEX_M33
@@ -226,6 +240,7 @@ config ARCH_SOCNAME
 	default "STM32F429" if ARCH_MCU_STM32F429
 	default "STM32F439" if ARCH_MCU_STM32F439
 	default "STM32L476" if ARCH_MCU_STM32L476
+	default "STM32H573" if ARCH_MCU_STM32H573
 	default "STM32U534" if ARCH_MCU_STM32U534
 	default "STM32U535" if ARCH_MCU_STM32U535
 	default "STM32U545" if ARCH_MCU_STM32U545
@@ -267,6 +282,10 @@ config ARCH_MCU_STM32WB55_CM4
 config ARCH_MCU_STM32L476
 	bool "STM32L476"
 	select SOC_SUBFAMILY_STM32L47_8x
+
+config ARCH_MCU_STM32H573
+	bool "STM32H573"
+	select SOC_SUBFAMILY_STM32H5
 
 config ARCH_MCU_STM32U595
 	bool "STM32U595"


### PR DESCRIPTION
Add stm32h5 basic support

- [x] kconfig soc entries
- [ ] clock/rcc
- [ ] rng
- [ ] exti
- [ ] pwr
- [ ] lpuart